### PR TITLE
Allow specifying empty extras

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -473,7 +473,7 @@ class StandardMetadata:
         except KeyError:
             return {}
 
-        requirements_dict: collections.defaultdict[str, list[Requirement]] = collections.defaultdict(list)
+        requirements_dict: dict[str, list[Requirement]] = {}
         if not isinstance(val, dict):
             msg = (
                 'Field "project.optional-dependencies" has an invalid type, expecting a '
@@ -488,6 +488,7 @@ class StandardMetadata:
                     f'dictionary PEP 508 requirement strings (got "{requirements}")'
                 )
                 raise ConfigurationError(msg)
+            requirements_dict[extra] = []
             for req in requirements:
                 if not isinstance(req, str):
                     msg = (

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -709,6 +709,7 @@ def test_as_rfc822_set_metadata(metadata_version):
                     'under_score': ['some_package'],
                     'da-sh': ['some-package'],
                     'do.t': ['some.package'],
+                    'empty': [],
                 },
             }
         },
@@ -723,6 +724,7 @@ def test_as_rfc822_set_metadata(metadata_version):
     assert 'Provides-Extra: under-score' in rfc822
     assert 'Provides-Extra: da-sh' in rfc822
     assert 'Provides-Extra: do-t' in rfc822
+    assert 'Provides-Extra: empty' in rfc822
     assert 'Requires-Dist: some_package; extra == "under-score"' in rfc822
     assert 'Requires-Dist: some-package; extra == "da-sh"' in rfc822
     assert 'Requires-Dist: some.package; extra == "do-t"' in rfc822


### PR DESCRIPTION
Other implementations of core metadata generation support specifying empty extras. These are useful for backwards compatibility purposes. For example,
<https://github.com/tiangolo/typer/discussions/785#discussioncomment-9032083>.

The Core metadata specifications document says:

> It is legal to specify `Provides-Extra:` without referencing it in any
> `Requires-Dist:`.

Ref: https://packaging.python.org/en/latest/specifications/core-metadata/#provides-extra-multiple-use