### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,15 @@
-name: Build & upload PyPI package
+name: Package
 
 on:
-  push:
-    tags: ["*"]
-
-permissions:
-  contents: read
-  id-token: write
+  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   # Always build & lint package.
   build-package:
-    name: Build & verify package
+    name: Build & verify
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +18,13 @@ jobs:
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
-    name: Publish released package to pypi.org
-    environment: release-pypi
+    name: Publish to pypi.org
+    environment: release
     runs-on: ubuntu-latest
     needs: build-package
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
 
     steps:
       - name: Download packages built by build-and-inspect-python-package


### PR DESCRIPTION
Updating the release workflow from #85 using values in #97. I've also switched this to trigger on GitHub releases, which is more controlled than anyone pushing a tag.
