### PR TITLE
fix: configuration error printout missing values

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -242,7 +242,7 @@ class StandardMetadata:
             raise ConfigurationError(msg)
 
         if metadata_version and metadata_version not in KNOWN_METADATA_VERSIONS:
-            msg = 'The metadata_version must be one of {KNOWN_METADATA_VERSIONS} or None (default)'
+            msg = f'The metadata_version must be one of {KNOWN_METADATA_VERSIONS} or None (default)'
             raise ConfigurationError(msg)
 
         return cls(

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -729,6 +729,21 @@ def test_as_rfc822_set_metadata(metadata_version):
     assert 'Requires-Dist: some-package; extra == "da-sh"' in rfc822
     assert 'Requires-Dist: some.package; extra == "do-t"' in rfc822
 
+def test_as_rfc822_set_metadata_invalid():
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='The metadata_version must be one of') as err:
+        pyproject_metadata.StandardMetadata.from_pyproject(
+            {
+                'project': {
+                    'name': 'hi',
+                    'version': '1.2',
+                    },
+            },
+            metadata_version='2.0',
+        )
+    assert '2.1' in str(err.value)
+    assert '2.2' in str(err.value)
+    assert '2.3' in str(err.value)
+
 
 def test_as_rfc822_invalid_dynamic():
     metadata = pyproject_metadata.StandardMetadata(


### PR DESCRIPTION
This was just filling out 100% coverage noticed by #94, but found a small error message fix, missing f-string.
