### PR TITLE
revert: validate description

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -241,11 +241,10 @@ class StandardMetadata:
             msg = 'Field "project.version" missing and "version" not specified in "project.dynamic"'
             raise ConfigurationError(msg)
 
-        # Description can't be multiline
+        # Description fills Summary, which cannot be multiline
+        # However, throwing an error isn't backward compatible,
+        # so leave it up to the users for now.
         description = fetcher.get_str('project.description')
-        if description and '\n' in description:
-            msg = 'The description must be a single line'
-            raise ConfigurationError(msg)
 
         if metadata_version and metadata_version not in KNOWN_METADATA_VERSIONS:
             msg = f'The metadata_version must be one of {KNOWN_METADATA_VERSIONS} or None (default)'

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -232,16 +232,6 @@ from .conftest import cd_package
             '''),
             ('Field "project.description" has an invalid type, expecting a string (got "True")'),
         ),
-        (
-            textwrap.dedent('''
-                [project]
-                name = 'test'
-                version = '0.1.0'
-                description = """Multiple
-                lines."""
-            '''),
-            ('The description must be a single line'),
-        ),
         # dependencies
         (
             textwrap.dedent('''


### PR DESCRIPTION
This reverts #76, as it's not a backward compatible change. See #30 for details.
