### PR TITLE
ci: macos-latest now points at macos-14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
           - '3.11'
           - '3.12'
         include:
-          - os: macos-latest
+          - os: macos-13
             python: '3.7'
-          - os: macos-latest
+          - os: macos-14
             python: '3.12'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python for nox
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install nox
         run: |


### PR DESCRIPTION
ARM is fine, no Python 3.8 or 3.9 is not.