### PR TITLE
metadata: validate entrypoint group names

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -542,6 +542,12 @@ class StandardMetadata:
             raise ConfigurationError(msg)
         for section, entrypoints in val.items():
             assert isinstance(section, str)
+            if not re.match(r'^\w+(\.\w+)*$', section):
+                msg = (
+                    'Field "project.entry-points" has an invalid value, expecting a name '
+                    f'containing only alphanumeric, underscore, or dot characters (got "{section}")'
+                )
+                raise ConfigurationError(msg)
             if not isinstance(entrypoints, dict):
                 msg = (
                     f'Field "project.entry-points.{section}" has an invalid type, expecting a '

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -584,6 +584,18 @@ from .conftest import cd_package
                 'numbers, period, underscore and hyphen. It must start and end with a letter or number'
             ),
         ),
+        (
+            textwrap.dedent("""
+                [project]
+                name = 'test'
+                version = '0.1.0'
+                [project.entry-points.bad-name]
+            """),
+            (
+                'Field "project.entry-points" has an invalid value, expecting a name containing only '
+                'alphanumeric, underscore, or dot characters (got "bad-name")'
+            ),
+        ),
     ],
 )
 @pytest.mark.usefixtures('package')


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>