### PR TITLE
refactor: move fetcher methods

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -97,9 +97,7 @@ class DataFetcher:
     def __init__(self, data: Mapping[str, Any]) -> None:
         self._data = data
 
-    def __contains__(self, key: Any) -> bool:
-        if not isinstance(key, str):
-            return False
+    def __contains__(self, key: str) -> bool:
         val = self._data
         try:
             for part in key.split('.'):

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -255,10 +255,7 @@ class ProjectFetcher(DataFetcher):
         return Readme(text, file, content_type)
 
     def get_dependencies(self) -> list[Requirement]:
-        try:
-            requirement_strings = self.get_list('project.dependencies')
-        except KeyError:
-            return []
+        requirement_strings = self.get_list('project.dependencies')
 
         requirements: list[Requirement] = []
         for req in requirement_strings:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,0 +1,5 @@
+import pyproject_metadata
+
+
+def test_all():
+    assert 'typing' not in dir(pyproject_metadata)


### PR DESCRIPTION
This is some refactoring for the fetcher methods that didn't live inside the fetcher.

Originally I was moving them to free functions, which is why the `__all__` addition is here.

Coverage is 100% now.