### PR TITLE
tests: fix coverage context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ quote-style = "single"
 
 
 [tool.coverage]
+run.dynamic_context = "test_function"
 html.show_contexts = true
 report.exclude_also = [
     "if typing.TYPE_CHECKING:",

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -572,7 +572,7 @@ from .conftest import cd_package
                 'Field "project.entry-points.section.entrypoint" has an invalid type, expecting a string (got "[]")'
             ),
         ),
-        # invalid mame
+        # invalid name
         (
             textwrap.dedent("""
                 [project]


### PR DESCRIPTION
This was producing an annoying in the test output, since we were requesting the html context, but not enabling it.
