### PR TITLE
feat: validate extra keys (warning, opt-in error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ you can use it as a library in your scripts and programs:
 from pyproject_metadata import StandardMetadata
 
 parsed_pyproject = { ... }  # you can use parsers like `tomli` to obtain this dict
-metadata = StandardMetadata.from_pyproject(parsed_pyproject)
+metadata = StandardMetadata.from_pyproject(parsed_pyproject, allow_extra_keys = False)
 print(metadata.entrypoints)  # same fields as defined in PEP 621
 
 pkg_info = metadata.as_rfc822()

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -895,6 +895,22 @@ def test_version_dynamic() -> None:
     assert 'version' not in metadata.dynamic
 
 
+def test_missing_keys_warns() -> None:
+    with pytest.warns(
+        pyproject_metadata.ConfigurationWarning,
+        match=re.escape("""Extra keys present in "project": {'not-real-key'}"""),
+    ):
+        pyproject_metadata.StandardMetadata.from_pyproject(
+            {
+                'project': {
+                    'name': 'example',
+                    'version': '1.2.3',
+                    'not-real-key': True,
+                },
+            }
+        )
+
+
 def test_missing_keys_okay() -> None:
     pyproject_metadata.StandardMetadata.from_pyproject(
         {

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -46,6 +46,14 @@ DIR = pathlib.Path(__file__).parent.resolve()
         pytest.param(
             """
                 [project]
+                not-real-key = true
+            """,
+            'Extra keys present in "project": {\'not-real-key\'}',
+            id='Invalid project key',
+        ),
+        pytest.param(
+            """
+                [project]
                 name = true
                 version = '0.1.0'
                 dynamic = [
@@ -589,7 +597,8 @@ def test_load(data: str, error: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(DIR / 'packages/full-metadata')
     with pytest.raises(pyproject_metadata.ConfigurationError, match=re.escape(error)):
         pyproject_metadata.StandardMetadata.from_pyproject(
-            tomllib.loads(textwrap.dedent(data))
+            tomllib.loads(textwrap.dedent(data)),
+            allow_extra_keys=False,
         )
 
 
@@ -884,3 +893,54 @@ def test_version_dynamic() -> None:
     )
     metadata.version = packaging.version.Version('1.2.3')
     assert 'version' not in metadata.dynamic
+
+
+def test_missing_keys_okay() -> None:
+    pyproject_metadata.StandardMetadata.from_pyproject(
+        {
+            'project': {'name': 'example', 'version': '1.2.3', 'not-real-key': True},
+        },
+        allow_extra_keys=True,
+    )
+
+
+def test_extra_top_level() -> None:
+    pyproject_metadata.validate_top_level(
+        {
+            'project': {},
+        }
+    )
+    with pytest.raises(
+        pyproject_metadata.ConfigurationError,
+        match=r"Extra keys present in pyproject.toml: \{'(also-|)not-real', '(also-|)not-real'\}",
+    ):
+        pyproject_metadata.validate_top_level(
+            {
+                'not-real': {},
+                'also-not-real': {},
+            }
+        )
+
+
+def test_extra_build_system() -> None:
+    pyproject_metadata.validate_build_system(
+        {
+            'build-system': {
+                'build-backend': 'one',
+                'requires': ['two'],
+                'backend-path': 'local',
+            },
+        }
+    )
+    with pytest.raises(
+        pyproject_metadata.ConfigurationError,
+        match=r"""Extra keys present in "build-system": \{'(also-|)not-real', '(also-|)not-real'\}""",
+    ):
+        pyproject_metadata.validate_build_system(
+            {
+                'build-system': {
+                    'not-real': {},
+                    'also-not-real': {},
+                }
+            }
+        )


### PR DESCRIPTION
Fix #12. ~~This is currently opt-in, though I think it could be made opt-out in the future.~~ Edit: made it default to warning, opt-in for strict or ignore.

There are also two extra helper functions to validate the rest of the pyproject.toml for extra keys. But this is stricter than the project table, which is all that pyproject-metadata handles, so those are not potentially opt-out or even "integrated", but just helpers to provide a consistent error system if backends want to use it (I think most would, I will be calling them too in scikit-build-core).

These could be turned into warnings by backends if they prefer by catching the error and emitting a warning. `allow_extra_keys=None` could produce a warning,actually, that's not a bad idea and a pretty reasonable default. Edit: done.