### PR TITLE
fix: match EmailMessage spacing

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -85,8 +85,9 @@ class RFC822Message:
                 text += f'{name}: {lines[0]}\n'
                 for line in lines[1:]:
                     text += ' ' * 8 + line + '\n'
+        text += '\n'
         if self.body:
-            text += '\n' + self.body
+            text += self.body
         return text
 
     def __bytes__(self) -> bytes:

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -100,7 +100,7 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
     for name, value in items:
         message[name] = value
 
-    data = textwrap.dedent(data)
+    data = textwrap.dedent(data) + "\n"
     assert str(message) == data
     assert bytes(message) == data.encode()
 

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -100,7 +100,7 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
     for name, value in items:
         message[name] = value
 
-    data = textwrap.dedent(data) + "\n"
+    data = textwrap.dedent(data) + '\n'
     assert str(message) == data
     assert bytes(message) == data.encode()
 


### PR DESCRIPTION
This brings us more in line with the spacing from `email.message.EmailMessage`.
