### PR TITLE
fix: add multiline warning

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -133,6 +133,8 @@ class _SmartMessageSetter:
         if not value:
             return
         if '\n' in value:
+            msg = f'"{name}" should not be multiline; indenting to avoid breakage'
+            warnings.warn(msg, ConfigurationWarning, stacklevel=2)
             value = value.replace('\n', '\n        ')
         self.message[name] = value
 

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import textwrap
 
 import pytest
@@ -99,7 +100,14 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
     smart_message = pyproject_metadata._SmartMessageSetter(message)
 
     for name, value in items:
-        smart_message[name] = value
+        if value and '\n' in value:
+            msg = '"ItemB" should not be multiline; indenting to avoid breakage'
+            with pytest.warns(
+                pyproject_metadata.ConfigurationWarning, match=re.escape(msg)
+            ):
+                smart_message[name] = value
+        else:
+            smart_message[name] = value
 
     data = textwrap.dedent(data) + '\n'
     assert str(message) == data


### PR DESCRIPTION
This adds a warning in followup to https://github.com/pypa/pyproject-metadata/pull/142#discussion_r1757557104.
