### PR TITLE
docs: prepare changelog for 0.9.0b1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,28 +44,8 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
-      - name: Pick environment to run
-        run: |
-          import platform; import os; import sys; import codecs
-          base = '.'.join(map(str, sys.version_info[:2]))
-          env = f'BASE={base}\n'
-          print(f'Picked:\n{env}for{sys.version}')
-          with codecs.open(os.environ['GITHUB_ENV'], 'a', 'utf-8') as file_handler:
-               file_handler.write(env)
-        shell: python
-
-      - name: Set up Python for nox
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install nox
-        run: |
-            python -m pip install nox
-            nox --version
-
       - name: Run tests
-        run: nox -s test-${{ env.BASE }}
+        run: pipx run nox -s test-${{ matrix.python }}
 
       - name: Send coverage report
         uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,15 @@
 name: tests
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pytest:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,49 @@
 Changelog
 +++++++++
 
+0.9.0 beta 1 (13-09-2024)
+=========================
+
+This release adds PEP 639 support (METADATA 2.4), refactors the RFC messages,
+and adds a lot of validation (including warnings and opt-in errors). The beta
+release is intended for backend authors to try out the changes before a final
+release.
+
+Features:
+
+- Added PEP 639 support for SPDX license and license files, METADATA 2.4
+- Validate extra keys (warning, opt-in error)
+- Validate project name
+- Validate entrypoint group names
+- Add multiline warning
+
+Fixes:
+
+- Correct typing for emails
+- Match EmailMessage spacing
+
+
+Refactoring:
+
+- Move fetcher methods
+- Put validation in function
+- Prepare for EmailMessage
+- Use EmailMessage class
+
+
+Internal and CI:
+
+- Add 3.13 to testing
+- Add ruff-format
+- Actions and dependabot
+- Better changelog auto-generation
+- Generate attestations for releases
+- ``macos-latest`` now points at ``macos-14``
+- Refactor and cleanup tests
+- Add human readable IDs to tests
+- Fix coverage context
+
+
 0.8.0 (17-04-2024)
 ==================
 


### PR DESCRIPTION
Getting ready for a beta release, to make it easier for backend authors to test out PEP 639 and the new validation errors and warnings.
