### PR TITLE
fix: add unicode and join multilines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = ["LICENSE", "tests/**", "docs/**", "CHANGELOG.rst"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
 log_cli_level = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = ["LICENSE", "tests/**", "docs/**", "CHANGELOG.rst"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
 log_cli_level = "info"

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-import email.headerregistry
 import email.message
 import email.policy
 import email.utils
@@ -115,7 +114,6 @@ class ConfigurationError(Exception):
 
 class ConfigurationWarning(UserWarning):
     """Warnings about backend metadata."""
-
 
 
 @dataclasses.dataclass

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -137,13 +137,13 @@ class _SmartMessageSetter:
 class MetadataPolicy(email.policy.Compat32):
     utf8 = True
 
-    def fold(self, name, value):
+    def fold(self, name: str, value: str) -> str:
         size = len(name) + 2
-        value = value.replace('\n', '\n' + ' '*size)
-        return f"{name}: {value}\n"
+        value = value.replace('\n', '\n' + ' ' * size)
+        return f'{name}: {value}\n'
 
-    def fold_binary(self, name, value):
-        return self.fold(name, value).encode("utf-8")
+    def fold_binary(self, name: str, value: str) -> bytes:
+        return self.fold(name, value).encode('utf-8')
 
 
 class DataFetcher:
@@ -613,7 +613,7 @@ class StandardMetadata:
             self._update_dynamic(value)
         super().__setattr__(name, value)
 
-    def as_rfc822(self) -> email.message.EmailMessage:
+    def as_rfc822(self) -> email.message.EmailMessage:  # noqa: C901
         self.validate(warn=False)
 
         message = email.message.EmailMessage(policy=MetadataPolicy())

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -132,10 +132,11 @@ class _SmartMessageSetter:
     def __setitem__(self, name: str, value: str | None) -> None:
         if not value:
             return
-        if '\n' in value:
-            msg = f'"{name}" should not be multiline; indenting to avoid breakage'
+        lines = value.splitlines()
+        if len(lines) > 1:
+            msg = f'"{name}" should not be multiline; joining to avoid breakage'
             warnings.warn(msg, ConfigurationWarning, stacklevel=2)
-            value = value.replace('\n', '\n        ')
+            value = ' '.join(lines)
         self.message[name] = value
 
 
@@ -145,10 +146,8 @@ class RFC822Message(email.message.EmailMessage):
     __slots__ = ()
 
     def __init__(self) -> None:
-        super().__init__(email.policy.compat32)
-
-    def __str__(self) -> str:
-        return bytes(self).decode('utf-8')
+        policy = email.policy.EmailPolicy(max_line_length=0, utf8=True)
+        super().__init__(policy)
 
 
 class DataFetcher:

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -119,14 +119,14 @@ class ConfigurationWarning(UserWarning):
 @dataclasses.dataclass
 class _SmartMessageSetter:
     """
-    This provides a nice internal API for setting values in an EmailMessage to
+    This provides a nice internal API for setting values in an Message to
     reduce boilerplate.
 
     If a value is None, do nothing.
     If a value contains a newline, indent it (may produce a warning in the future).
     """
 
-    message: email.message.EmailMessage
+    message: email.message.Message
 
     def __setitem__(self, name: str, value: str | None) -> None:
         if not value:
@@ -135,8 +135,6 @@ class _SmartMessageSetter:
 
 
 class MetadataPolicy(email.policy.Compat32):
-    utf8 = True
-
     def fold(self, name: str, value: str) -> str:
         size = len(name) + 2
         value = value.replace('\n', '\n' + ' ' * size)
@@ -613,10 +611,10 @@ class StandardMetadata:
             self._update_dynamic(value)
         super().__setattr__(name, value)
 
-    def as_rfc822(self) -> email.message.EmailMessage:  # noqa: C901
+    def as_rfc822(self) -> email.message.Message:  # noqa: C901
         self.validate(warn=False)
 
-        message = email.message.EmailMessage(policy=MetadataPolicy())
+        message = email.message.Message(policy=MetadataPolicy())
         smart_message = _SmartMessageSetter(message)
 
         smart_message['Metadata-Version'] = self.metadata_version

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import re
+import email.message
 import textwrap
 
 import pytest
 
 import pyproject_metadata
-import email.message
 
 
 @pytest.mark.parametrize(
@@ -114,6 +113,10 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
     assert str(message) == data
     assert bytes(message) == data.encode()
 
+    assert email.message_from_string(str(message)).items() == [
+        (a, '\n       '.join(b.splitlines())) for a, b in items if b is not None
+    ]
+
 
 def test_body() -> None:
     message = email.message.EmailMessage(policy=pyproject_metadata.MetadataPolicy())
@@ -158,6 +161,10 @@ def test_body() -> None:
         finibus nulla. Donec sit amet ante in neque pulvinar faucibus sed nec justo.
         Fusce hendrerit massa libero, sit amet pulvinar magna tempor quis. ø
     """)
+
+    new_message = email.message_from_string(str(message))
+    assert new_message.items() == message.items()
+    assert new_message.get_payload() == message.get_payload()
 
 
 def test_convert_optional_dependencies() -> None:

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -32,6 +32,13 @@ import pyproject_metadata
             Foo2: Bar2
             """,
         ),
+        # Unicode
+        (
+            [
+                ('Foo', 'Unicøde'),
+            ],
+            'Foo: Unicøde\n',
+        ),
         # None
         (
             [
@@ -87,9 +94,7 @@ import pyproject_metadata
             ],
             """\
             ItemA: ValueA
-            ItemB: ValueB1
-                    ValueB2
-                    ValueB3
+            ItemB: ValueB1 ValueB2 ValueB3
             ItemC: ValueC
             """,
         ),
@@ -101,7 +106,7 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
 
     for name, value in items:
         if value and '\n' in value:
-            msg = '"ItemB" should not be multiline; indenting to avoid breakage'
+            msg = '"ItemB" should not be multiline; joining to avoid breakage'
             with pytest.warns(
                 pyproject_metadata.ConfigurationWarning, match=re.escape(msg)
             ):
@@ -134,7 +139,7 @@ def test_body() -> None:
         dolor id elementum. Ut bibendum nunc interdum neque interdum, vel tincidunt
         lacus blandit. Ut volutpat sollicitudin dapibus. Integer vitae lacinia ex, eget
         finibus nulla. Donec sit amet ante in neque pulvinar faucibus sed nec justo.
-        Fusce hendrerit massa libero, sit amet pulvinar magna tempor quis.
+        Fusce hendrerit massa libero, sit amet pulvinar magna tempor quis. ø
     """)
     )
 
@@ -155,7 +160,7 @@ def test_body() -> None:
         dolor id elementum. Ut bibendum nunc interdum neque interdum, vel tincidunt
         lacus blandit. Ut volutpat sollicitudin dapibus. Integer vitae lacinia ex, eget
         finibus nulla. Donec sit amet ante in neque pulvinar faucibus sed nec justo.
-        Fusce hendrerit massa libero, sit amet pulvinar magna tempor quis.
+        Fusce hendrerit massa libero, sit amet pulvinar magna tempor quis. ø
     """)
 
 

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -103,7 +103,7 @@ import pyproject_metadata
     ],
 )
 def test_headers(items: list[tuple[str, str]], data: str) -> None:
-    message = email.message.EmailMessage(policy=pyproject_metadata.MetadataPolicy())
+    message = email.message.Message(policy=pyproject_metadata.MetadataPolicy())
     smart_message = pyproject_metadata._SmartMessageSetter(message)
 
     for name, value in items:
@@ -119,7 +119,7 @@ def test_headers(items: list[tuple[str, str]], data: str) -> None:
 
 
 def test_body() -> None:
-    message = email.message.EmailMessage(policy=pyproject_metadata.MetadataPolicy())
+    message = email.message.Message(policy=pyproject_metadata.MetadataPolicy())
 
     message['ItemA'] = 'ValueA'
     message['ItemB'] = 'ValueB'


### PR DESCRIPTION
Fix for #149. Changes:

* Support unicode METADATA
* Remove the custom `RFC822Message` entirely, replaced with a custom Policy (which also handles multilines
* Handle multiline the way setuptools does with smart indentation
* Remove `write_to_rfc822`
* Remove the multiline warning for all metadata
* Add some unicode and reading tests
* Swap `EmailMessage` for `Message`