### PR TITLE
fix: handle bytes() if payload has unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ metadata = StandardMetadata.from_pyproject(parsed_pyproject, allow_extra_keys = 
 print(metadata.entrypoints)  # same fields as defined in PEP 621
 
 pkg_info = metadata.as_rfc822()
-print(bytes(pkg_info).decode("utf-8"))  # core metadata
+print(str(pkg_info)))  # core metadata
 ```
 
 ## METADATA 2.4

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -623,10 +623,14 @@ class StandardMetadata:
             self._update_dynamic(value)
         super().__setattr__(name, value)
 
-    def as_rfc822(self) -> RFC822Message:  # noqa: C901
+    def as_rfc822(self) -> RFC822Message:
+        message = RFC822Message()
+        self.write_to_rfc822(message)
+        return message
+
+    def write_to_rfc822(self, message: email.message.EmailMessage) -> None:  # noqa: C901
         self.validate(warn=False)
 
-        message = RFC822Message()
         smart_message = _SmartMessageSetter(message)
 
         smart_message['Metadata-Version'] = self.metadata_version
@@ -686,8 +690,6 @@ class StandardMetadata:
                     msg = f'Field cannot be dynamic: {field}'
                     raise ConfigurationError(msg)
                 smart_message['Dynamic'] = field
-
-        return message
 
     def _name_list(self, people: list[tuple[str, str | None]]) -> str:
         return ', '.join(name for name, email_ in people if not email_)

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -68,11 +68,12 @@ __all__ = [
     'ConfigurationWarning',
     'License',
     'RFC822Message',
+    'RFC822Policy',
     'Readme',
     'StandardMetadata',
-    'validate_top_level',
     'validate_build_system',
     'validate_project',
+    'validate_top_level',
 ]
 
 
@@ -135,7 +136,12 @@ class _SmartMessageSetter:
         self.message[name] = value
 
 
-class MetadataPolicy(email.policy.EmailPolicy):
+class RFC822Policy(email.policy.EmailPolicy):
+    """
+    This is `email.policy.EmailPolicy`, but with a simple ``header_store_parse``
+    implementation that handles multiline values, and some nice defaults.
+    """
+
     utf8 = True
     mangle_from_ = False
     max_line_length = 0
@@ -147,8 +153,14 @@ class MetadataPolicy(email.policy.EmailPolicy):
 
 
 class RFC822Message(email.message.EmailMessage):
+    """
+    This is `email.message.EmailMessage` with two small changes: it defaults to
+    our `RFC822Policy`, and it correctly writes unicode when being called
+    with `bytes()`.
+    """
+
     def __init__(self) -> None:
-        super().__init__(policy=MetadataPolicy())
+        super().__init__(policy=RFC822Policy())
 
     def as_bytes(
         self, unixfrom: bool = False, policy: email.policy.Policy | None = None


### PR DESCRIPTION
Try for #149 again. RFC822Message is back, but based on EmailMessage. A slightly better name for it might be `UnicodeMessage`. Restoring `write_to_rfc822`.