### PR TITLE
refactor: dataclass instead of named tuple

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -439,12 +439,14 @@ class ProjectFetcher(DataFetcher):
         return val
 
 
-class License(typing.NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class License:
     text: str
     file: pathlib.Path | None
 
 
-class Readme(typing.NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class Readme:
     text: str
     file: pathlib.Path | None
     content_type: str


### PR DESCRIPTION
Dataclasses don't leak unused APIs like iteration, unpacking, Sequence, etc.
