### PR TITLE
refactor: rework how dynamic works

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pkg_info = metadata.as_rfc822()
 print(str(pkg_info)))  # core metadata
 ```
 
-## METADATA 2.4
+## SPDX licenses (METADATA 2.4+)
 
 If `project.license` is a string or `project.license-files` is present, then
 METADATA 2.4+ will be used. A user is expected to validate and normalize
@@ -51,3 +51,13 @@ folder, preserving the original source structure.
 
 
 [core metadata]: https://packaging.python.org/specifications/core-metadata/
+
+
+## Dynamic Metadata (METADATA 2.2+)
+
+Pyproject-metadata supports dynamic metadata. To use it, specify your METADATA fields in `dynamic_metadata`. If you want to convert `pyproject.toml` field names to METADATA field(s), use `pyproject_metadata.pyproject_to_metadata("field-name")`, which will return a frozenset of metadata names that are touched by that field.
+
+
+## Adding extra fields
+
+You can add extra fields to the Message returned by `to_rfc822()`, as long as they are valid metadata entries.

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -483,11 +483,9 @@ class StandardMetadata:
     """
 
     metadata_version: str | None = None
-    _initialized: bool = False
 
     def __post_init__(self) -> None:
         self.validate()
-        self._initialized = True
 
     def validate(self, *, warn: bool = True) -> None:
         if self.auto_metadata_version not in KNOWN_METADATA_VERSIONS:
@@ -639,17 +637,6 @@ class StandardMetadata:
             metadata_dynamic=metadata_dynamic or [],
             metadata_version=metadata_version,
         )
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # Only allow setting dynamic fields
-        if self._initialized and name not in set(self.dynamic) | {
-            'metadata_version',
-            'metadata_dynamic',
-        }:
-            msg = f'Field "{name}" is not dynamic'
-            raise AttributeError(msg)
-
-        super().__setattr__(name, value)
 
     def as_rfc822(self) -> RFC822Message:
         message = RFC822Message()

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -523,7 +523,7 @@ class StandardMetadata:
     """
     This field is used to track dynamic fields. You can't set a field not in this list.
     """
-    metadata_dynamic: list[str] = dataclasses.field(default_factory=list)
+    dynamic_metadata: list[str] = dataclasses.field(default_factory=list)
     """
     This is a list of METADATA fields that can change inbetween SDist and wheel. Requires metadata_version 2.2+.
     """
@@ -594,7 +594,7 @@ class StandardMetadata:
 
         if isinstance(self.license, str) or self.license_files is not None:
             return '2.4'
-        if self.metadata_dynamic:
+        if self.dynamic_metadata:
             return '2.2'
         return '2.1'
 
@@ -608,7 +608,7 @@ class StandardMetadata:
         data: Mapping[str, Any],
         project_dir: str | os.PathLike[str] = os.path.curdir,
         metadata_version: str | None = None,
-        metadata_dynamic: list[str] | None = None,
+        dynamic_metadata: list[str] | None = None,
         *,
         allow_extra_keys: bool | None = None,
     ) -> Self:
@@ -680,7 +680,7 @@ class StandardMetadata:
             scripts=fetcher.get_dict('project.scripts'),
             gui_scripts=fetcher.get_dict('project.gui-scripts'),
             dynamic=dynamic,
-            metadata_dynamic=metadata_dynamic or [],
+            dynamic_metadata=dynamic_metadata or [],
             metadata_version=metadata_version,
         )
 
@@ -746,7 +746,7 @@ class StandardMetadata:
             message.set_payload(self.readme.text)
         # Core Metadata 2.2
         if self.auto_metadata_version != '2.1':
-            for field in self.metadata_dynamic:
+            for field in self.dynamic_metadata:
                 if field.lower() in {'name', 'version', 'dynamic'}:
                     msg = f'Field cannot be set as dynamic metadata: {field}'
                     raise ConfigurationError(msg)

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -907,6 +907,7 @@ def test_as_rfc822_dynamic(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
+    metadata.metadata_dynamic = ['description']
     core_metadata = metadata.as_rfc822()
     assert core_metadata.items() == [
         ('Metadata-Version', '2.2'),
@@ -971,15 +972,17 @@ def test_as_rfc822_invalid_dynamic() -> None:
     metadata = pyproject_metadata.StandardMetadata(
         name='something',
         version=packaging.version.Version('1.0.0'),
+        metadata_dynamic=['name'],
     )
-    metadata.dynamic = ['name']
     with pytest.raises(
-        pyproject_metadata.ConfigurationError, match='Field cannot be dynamic: name'
+        pyproject_metadata.ConfigurationError,
+        match='Field cannot be set as dynamic metadata: name',
     ):
         metadata.as_rfc822()
-    metadata.dynamic = ['version']
+    metadata.metadata_dynamic = ['version']
     with pytest.raises(
-        pyproject_metadata.ConfigurationError, match='Field cannot be dynamic: version'
+        pyproject_metadata.ConfigurationError,
+        match='Field cannot be set as dynamic metadata: version',
     ):
         metadata.as_rfc822()
 
@@ -1043,7 +1046,6 @@ def test_version_dynamic() -> None:
         }
     )
     metadata.version = packaging.version.Version('1.2.3')
-    assert 'version' not in metadata.dynamic
 
 
 def test_missing_keys_warns() -> None:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -907,7 +907,7 @@ def test_as_rfc822_dynamic(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
-    metadata.metadata_dynamic = ['description']
+    metadata.dynamic_metadata = ['description']
     core_metadata = metadata.as_rfc822()
     assert core_metadata.items() == [
         ('Metadata-Version', '2.2'),
@@ -972,20 +972,20 @@ def test_as_rfc822_invalid_dynamic() -> None:
     metadata = pyproject_metadata.StandardMetadata(
         name='something',
         version=packaging.version.Version('1.0.0'),
-        metadata_dynamic=['name'],
+        dynamic_metadata=['name'],
     )
     with pytest.raises(
         pyproject_metadata.ConfigurationError,
         match='Field cannot be set as dynamic metadata: name',
     ):
         metadata.as_rfc822()
-    metadata.metadata_dynamic = ['version']
+    metadata.dynamic_metadata = ['version']
     with pytest.raises(
         pyproject_metadata.ConfigurationError,
         match='Field cannot be set as dynamic metadata: version',
     ):
         metadata.as_rfc822()
-    metadata.metadata_dynamic = ['unknown']
+    metadata.dynamic_metadata = ['unknown']
     with pytest.raises(
         pyproject_metadata.ConfigurationError,
         match='Field is not known: unknown',
@@ -997,7 +997,7 @@ def test_as_rfc822_mapped_dynamic() -> None:
     metadata = pyproject_metadata.StandardMetadata(
         name='something',
         version=packaging.version.Version('1.0.0'),
-        metadata_dynamic=list(pyproject_metadata.field_to_metadata('description')),
+        dynamic_metadata=list(pyproject_metadata.field_to_metadata('description')),
     )
     assert (
         str(metadata.as_rfc822())

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -985,6 +985,24 @@ def test_as_rfc822_invalid_dynamic() -> None:
         match='Field cannot be set as dynamic metadata: version',
     ):
         metadata.as_rfc822()
+    metadata.metadata_dynamic = ['unknown']
+    with pytest.raises(
+        pyproject_metadata.ConfigurationError,
+        match='Field is not known: unknown',
+    ):
+        metadata.as_rfc822()
+
+
+def test_as_rfc822_mapped_dynamic() -> None:
+    metadata = pyproject_metadata.StandardMetadata(
+        name='something',
+        version=packaging.version.Version('1.0.0'),
+        metadata_dynamic=list(pyproject_metadata.field_to_metadata('description')),
+    )
+    assert (
+        str(metadata.as_rfc822())
+        == 'Metadata-Version: 2.2\nName: something\nVersion: 1.0.0\nDynamic: Summary\n\n'
+    )
 
 
 def test_as_rfc822_missing_version() -> None:


### PR DESCRIPTION
This reworks how "dynamic" works. The old way was quite broken: Because a field is project dynamic, that doesn't mean it's METADATA dynamic. And the METADATA dynamic field names are METADATA names, not project names.

This has to be split into two concepts. There's a new `metadata_dynamic` value that backends can set if they are setting dynamic metadata. If we provide a mapping, we can specify this as project field names, currently it's just METADATA field names. Will have to see which makes the most sense. This _must_ be set by the backend if it wants to make a METADATA 2.2 dynamic field. It's not information present in the pyproject.toml. Though it is a strict subset (with appropriate name conversions).

~~The regular "dynamic" field now is used to keep users from setting any unlisted fields after creating the class.~~ (removed for now). A function to map names has been added.

See https://github.com/pypa/pyproject-metadata/issues/89. Fixes #51.
