### PR TITLE
docs: prepare for 0.9.0b4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,26 @@
 Changelog
 +++++++++
 
+0.9.0 (beta 4: 20-09-2024)
+==========================
+
+
+Features:
+
+* Setting a non-dynamic field is an error
+
+Fixes:
+
+- Warn on multiline Summary (``project.description``)
+
+Refactoring:
+
+* Remove indirection accessing metadata_version, add ``auto_metadata_version``
+* Rework how dynamic works, add ``dynamic_metadata``
+* Use dataclass instead of named tuple
+* chore: use named arguments instead of positional
+
+
 0.9.0 (beta 3: 13-09-2024)
 ==========================
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -34,7 +34,7 @@ import packaging.utils
 import packaging.version
 
 
-__version__ = '0.9.0b3'
+__version__ = '0.9.0b4'
 
 KNOWN_METADATA_VERSIONS = {'2.1', '2.2', '2.3', '2.4'}
 PRE_SPDX_METADATA_VERSIONS = {'2.1', '2.2', '2.3'}


### PR DESCRIPTION
After #162, so backends can test the dynamic metadata changes.
