### PR TITLE
feat: all_errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Pyproject-metadata supports dynamic metadata. To use it, specify your METADATA f
 
 You can add extra fields to the Message returned by `to_rfc822()`, as long as they are valid metadata entries.
 
+## Collecting multiple errors
+
+You can use the `all_errors` argument to `from_pyproject` to show all errors in
+the metadata parse at once, instead of raising an exception on the first one.
+The exception type will be `pyproject_metadata.errors.ExceptionGroup` (which is
+just `ExceptionGroup` on Python 3.11+).
+
 ## Validating classifiers
 
 If you want to validate classifiers, then install the `trove_classifiers` library (the canonical source for classifiers), and run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "pytest-cov[toml]>=2",
     "pytest>=6.2.4",
     'tomli>=1.0.0;python_version<"3.11"',
+    'exceptiongroup;python_version<"3.11"',  # Optional
 ]
 
 [project.urls]

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -70,7 +70,8 @@ def field_to_metadata(field: str) -> frozenset[str]:
 def validate_top_level(pyproject_table: Mapping[str, Any]) -> None:
     extra_keys = set(pyproject_table) - constants.KNOWN_TOPLEVEL_FIELDS
     if extra_keys:
-        msg = f'Extra keys present in pyproject.toml: {extra_keys}'
+        extra_keys_str = ', '.join(sorted(f'"{k}"' for k in extra_keys))
+        msg = f'Extra keys present in pyproject.toml: {extra_keys_str}'
         raise ConfigurationError(msg)
 
 
@@ -80,7 +81,8 @@ def validate_build_system(pyproject_table: Mapping[str, Any]) -> None:
         - constants.KNOWN_BUILD_SYSTEM_FIELDS
     )
     if extra_keys:
-        msg = f'Extra keys present in "build-system": {extra_keys}'
+        extra_keys_str = ', '.join(sorted(f'"{k}"' for k in extra_keys))
+        msg = f'Extra keys present in "build-system": {extra_keys_str}'
         raise ConfigurationError(msg)
 
 
@@ -89,7 +91,8 @@ def validate_project(pyproject_table: Mapping[str, Any]) -> None:
         set(pyproject_table.get('project', [])) - constants.KNOWN_PROJECT_FIELDS
     )
     if extra_keys:
-        msg = f'Extra keys present in "project": {extra_keys}'
+        extra_keys_str = ', '.join(sorted(f'"{k}"' for k in extra_keys))
+        msg = f'Extra keys present in "project": {extra_keys_str}'
         raise ConfigurationError(msg)
 
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -15,9 +15,9 @@ import sys
 import typing
 import warnings
 
-from . import constants, pyproject
-from .errors import ConfigurationError, ConfigurationWarning
-from .pyproject import License, Readme
+from . import constants
+from .errors import ConfigurationError, ConfigurationWarning, ErrorCollector
+from .pyproject import License, PyProjectReader, Readme
 
 
 if typing.TYPE_CHECKING:
@@ -210,6 +210,7 @@ class StandardMetadata:
     """
 
     metadata_version: str | None = None
+    all_errors: bool = False
     _locked_metadata: bool = False
 
     def __post_init__(self) -> None:
@@ -225,9 +226,11 @@ class StandardMetadata:
         super().__setattr__(name, value)
 
     def validate(self, *, warn: bool = True) -> None:  # noqa: C901
+        errors = ErrorCollector(collect_errors=self.all_errors)
+
         if self.auto_metadata_version not in constants.KNOWN_METADATA_VERSIONS:
             msg = f'The metadata_version must be one of {constants.KNOWN_METADATA_VERSIONS} or None (default)'
-            raise ConfigurationError(msg)
+            errors.config_error(msg)
 
         # See https://packaging.python.org/en/latest/specifications/core-metadata/#name and
         # https://packaging.python.org/en/latest/specifications/name-normalization/#name-format
@@ -238,17 +241,17 @@ class StandardMetadata:
                 f'Invalid project name "{self.name}". A valid name consists only of ASCII letters and '
                 'numbers, period, underscore and hyphen. It must start and end with a letter or number'
             )
-            raise ConfigurationError(msg)
+            errors.config_error(msg, key='project.name')
 
         if self.license_files is not None and isinstance(self.license, License):
             msg = '"project.license-files" must not be used when "project.license" is not a SPDX license expression'
-            raise ConfigurationError(msg)
+            errors.config_error(msg, key='project.license-files')
 
         if isinstance(self.license, str) and any(
             c.startswith('License ::') for c in self.classifiers
         ):
             msg = 'Setting "project.license" to an SPDX license expression is not compatible with "License ::" classifiers'
-            raise ConfigurationError(msg)
+            errors.config_error(msg, key='project.license')
 
         if warn:
             if self.description and '\n' in self.description:
@@ -276,14 +279,16 @@ class StandardMetadata:
             and self.auto_metadata_version in constants.PRE_SPDX_METADATA_VERSIONS
         ):
             msg = 'Setting "project.license" to an SPDX license expression is supported only when emitting metadata version >= 2.4'
-            raise ConfigurationError(msg)
+            errors.config_error(msg, key='project.license')
 
         if (
             self.license_files is not None
             and self.auto_metadata_version in constants.PRE_SPDX_METADATA_VERSIONS
         ):
             msg = '"project.license-files" is supported only when emitting metadata version >= 2.4'
-            raise ConfigurationError(msg)
+            errors.config_error(msg, key='project.license-files')
+
+        errors.finalize('Metadata validation failed')
 
     @property
     def auto_metadata_version(self) -> str:
@@ -301,7 +306,7 @@ class StandardMetadata:
         return packaging.utils.canonicalize_name(self.name)
 
     @classmethod
-    def from_pyproject(
+    def from_pyproject(  # noqa: C901
         cls,
         data: Mapping[str, Any],
         project_dir: str | os.PathLike[str] = os.path.curdir,
@@ -309,11 +314,17 @@ class StandardMetadata:
         dynamic_metadata: list[str] | None = None,
         *,
         allow_extra_keys: bool | None = None,
+        all_errors: bool = False,
     ) -> Self:
+        pyproject = PyProjectReader(collect_errors=all_errors)
+
         pyproject_table: PyProjectTable = data  # type: ignore[assignment]
         if 'project' not in pyproject_table:
             msg = 'Section "project" missing in pyproject.toml'
-            raise ConfigurationError(msg)
+            pyproject.config_error(msg, key='project')
+            pyproject.finalize('Failed to parse pyproject.toml')
+            msg = 'Unreachable code'  # pragma: no cover
+            raise AssertionError(msg)  # pragma: no cover
 
         project = pyproject_table['project']
         project_dir = pathlib.Path(project_dir)
@@ -324,76 +335,109 @@ class StandardMetadata:
             except ConfigurationError as err:
                 warnings.warn(str(err), ConfigurationWarning, stacklevel=2)
         elif not allow_extra_keys:
-            validate_project(data)
+            with pyproject.collect():
+                validate_project(data)
 
         dynamic = pyproject.get_dynamic(project)
 
         for field in dynamic:
             if field in data['project']:
                 msg = f'Field "project.{field}" declared as dynamic in "project.dynamic" but is defined'
-                raise ConfigurationError(msg)
+                pyproject.config_error(msg, key=field)
 
-        name = pyproject.ensure_str(project.get('name'), 'project.name')
-        if not name:
+        raw_name = project.get('name')
+        name = 'UNKNOWN'
+        if raw_name is None:
             msg = 'Field "project.name" missing'
-            raise ConfigurationError(msg)
+            pyproject.config_error(msg, key='name')
+        else:
+            tmp_name = pyproject.ensure_str(raw_name, 'project.name')
+            if tmp_name is not None:
+                name = tmp_name
 
-        version_string = pyproject.ensure_str(project.get('version'), 'project.version')
-        version = packaging.version.Version(version_string) if version_string else None
-
-        if version is None and 'version' not in dynamic:
+        version: packaging.version.Version | None = packaging.version.Version('0.0.0')
+        raw_version = project.get('version')
+        if raw_version is not None:
+            version_string = pyproject.ensure_str(raw_version, 'project.version')
+            if version_string is not None:
+                with pyproject.collect():
+                    version = (
+                        packaging.version.Version(version_string)
+                        if version_string
+                        else None
+                    )
+        elif 'version' not in dynamic:
             msg = 'Field "project.version" missing and "version" not specified in "project.dynamic"'
-            raise ConfigurationError(msg)
+            pyproject.config_error(msg, key='version')
 
         # Description fills Summary, which cannot be multiline
         # However, throwing an error isn't backward compatible,
         # so leave it up to the users for now.
-        description = pyproject.ensure_str(
-            project.get('description'), 'project.description'
-        )
-
-        requires_python_string = pyproject.ensure_str(
-            project.get('requires-python'), 'project.requires-python'
-        )
-        requires_python = (
-            packaging.specifiers.SpecifierSet(requires_python_string)
-            if requires_python_string
+        project_description_raw = project.get('description')
+        description = (
+            pyproject.ensure_str(project_description_raw, 'project.description')
+            if project_description_raw is not None
             else None
         )
 
-        self = cls(
-            name=name,
-            version=version,
-            description=description,
-            license=pyproject.get_license(project, project_dir),
-            license_files=pyproject.get_license_files(project, project_dir),
-            readme=pyproject.get_readme(project, project_dir),
-            requires_python=requires_python,
-            dependencies=pyproject.get_dependencies(project),
-            optional_dependencies=pyproject.get_optional_dependencies(project),
-            entrypoints=pyproject.get_entrypoints(project),
-            authors=pyproject.ensure_people(
-                project.get('authors', []), 'project.authors'
-            ),
-            maintainers=pyproject.ensure_people(
-                project.get('maintainers', []), 'project.maintainers'
-            ),
-            urls=pyproject.ensure_dict(project.get('urls'), 'project.urls'),
-            classifiers=pyproject.ensure_list(
-                project.get('classifiers'), 'project.classifiers'
+        requires_python_raw = project.get('requires-python')
+        requires_python = None
+        if requires_python_raw is not None:
+            requires_python_string = pyproject.ensure_str(
+                requires_python_raw, 'project.requires-python'
             )
-            or [],
-            keywords=pyproject.ensure_list(project.get('keywords'), 'project.keywords')
-            or [],
-            scripts=pyproject.ensure_dict(project.get('scripts'), 'project.scripts'),
-            gui_scripts=pyproject.ensure_dict(
-                project.get('gui-scripts'), 'project.gui-scripts'
-            ),
-            dynamic=dynamic,
-            dynamic_metadata=dynamic_metadata or [],
-            metadata_version=metadata_version,
-        )
-        self._locked_metadata = True
+            if requires_python_string is not None:
+                with pyproject.collect():
+                    requires_python = packaging.specifiers.SpecifierSet(
+                        requires_python_string
+                    )
+
+        self = None
+        with pyproject.collect():
+            self = cls(
+                name=name,
+                version=version,
+                description=description,
+                license=pyproject.get_license(project, project_dir),
+                license_files=pyproject.get_license_files(project, project_dir),
+                readme=pyproject.get_readme(project, project_dir),
+                requires_python=requires_python,
+                dependencies=pyproject.get_dependencies(project),
+                optional_dependencies=pyproject.get_optional_dependencies(project),
+                entrypoints=pyproject.get_entrypoints(project),
+                authors=pyproject.ensure_people(
+                    project.get('authors', []), 'project.authors'
+                ),
+                maintainers=pyproject.ensure_people(
+                    project.get('maintainers', []), 'project.maintainers'
+                ),
+                urls=pyproject.ensure_dict(project.get('urls', {}), 'project.urls')
+                or {},
+                classifiers=pyproject.ensure_list(
+                    project.get('classifiers', []), 'project.classifiers'
+                )
+                or [],
+                keywords=pyproject.ensure_list(
+                    project.get('keywords', []), 'project.keywords'
+                )
+                or [],
+                scripts=pyproject.ensure_dict(
+                    project.get('scripts', {}), 'project.scripts'
+                )
+                or {},
+                gui_scripts=pyproject.ensure_dict(
+                    project.get('gui-scripts', {}), 'project.gui-scripts'
+                )
+                or {},
+                dynamic=dynamic,
+                dynamic_metadata=dynamic_metadata or [],
+                metadata_version=metadata_version,
+                all_errors=all_errors,
+            )
+            self._locked_metadata = True
+
+        pyproject.finalize('Failed to parse pyproject.toml')
+        assert self is not None
         return self
 
     def as_rfc822(self) -> RFC822Message:

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
+import builtins
+import contextlib
+import dataclasses
+import sys
+import typing
 
-__all__ = ['ConfigurationError', 'ConfigurationWarning']
+import packaging.specifiers
+import packaging.version
+
+
+__all__ = [
+    'ConfigurationError',
+    'ConfigurationWarning',
+    'ExceptionGroup',
+    'ErrorCollector',
+]
 
 
 def __dir__() -> list[str]:
@@ -22,3 +36,55 @@ class ConfigurationError(Exception):
 
 class ConfigurationWarning(UserWarning):
     """Warnings about backend metadata."""
+
+
+if sys.version_info >= (3, 11):
+    ExceptionGroup = builtins.ExceptionGroup
+else:
+
+    class ExceptionGroup(Exception):
+        """A minimal implementation of `ExceptionGroup` from Python 3.11."""
+
+        message: str
+        exceptions: list[Exception]
+
+        def __init__(self, message: str, exceptions: list[Exception]) -> None:
+            self.message = message
+            self.exceptions = exceptions
+
+        def __repr__(self) -> str:
+            return f'{self.__class__.__name__}({self.message!r}, {self.exceptions!r})'
+
+
+@dataclasses.dataclass
+class ErrorCollector:
+    collect_errors: bool
+    errors: list[Exception] = dataclasses.field(default_factory=list)
+
+    def config_error(self, msg: str, key: str | None = None) -> None:
+        """Raise a configuration error, or add it to the error list."""
+        if self.collect_errors:
+            self.errors.append(ConfigurationError(msg, key=key))
+        else:
+            raise ConfigurationError(msg, key=key)
+
+    def finalize(self, msg: str) -> None:
+        """Raise a group exception if there are any errors."""
+        if self.errors:
+            raise ExceptionGroup(msg, self.errors)
+
+    @contextlib.contextmanager
+    def collect(self) -> typing.Generator[None, None, None]:
+        if self.collect_errors:
+            try:
+                yield
+            except (
+                ConfigurationError,
+                packaging.version.InvalidVersion,
+                packaging.specifiers.InvalidSpecifier,
+            ) as error:
+                self.errors.append(error)
+            except ExceptionGroup as error:
+                self.errors.extend(error.exceptions)
+        else:
+            yield

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -7,7 +7,7 @@ import typing
 
 import packaging.requirements
 
-from .errors import ConfigurationError
+from .errors import ErrorCollector
 
 
 __all__ = [
@@ -41,284 +41,326 @@ if typing.TYPE_CHECKING:
     from .project_table import ContactTable, ProjectTable
 
 
-def ensure_str(value: str | None, key: str) -> str | None:
-    if isinstance(value, str):
-        return value
-    if value is None:
+@dataclasses.dataclass
+class PyProjectReader(ErrorCollector):
+    def ensure_str(self, value: str, key: str) -> str | None:
+        if isinstance(value, str):
+            return value
+
+        msg = f'Field "{key}" has an invalid type, expecting a string (got "{value}")'
+        self.config_error(msg, key=key)
         return None
 
-    msg = f'Field "{key}" has an invalid type, expecting a string (got "{value}")'
-    raise ConfigurationError(msg, key=key)
+    def ensure_list(self, val: list[str], key: str) -> list[str] | None:
+        if not isinstance(val, list):
+            msg = f'Field "{key}" has an invalid type, expecting a list of strings (got "{val}")'
+            self.config_error(msg, key=key)
+            return None
+        for item in val:
+            if not isinstance(item, str):
+                msg = f'Field "{key}" contains item with invalid type, expecting a string (got "{item}")'
+                self.config_error(msg, key=key)
+                return None
 
-
-def ensure_list(val: list[str] | None, key: str) -> list[str] | None:
-    if val is None:
-        return None
-    if not isinstance(val, list):
-        msg = f'Field "{key}" has an invalid type, expecting a list of strings (got "{val}")'
-        raise ConfigurationError(msg, key=val)
-    for item in val:
-        if not isinstance(item, str):
-            msg = f'Field "{key}" contains item with invalid type, expecting a string (got "{item}")'
-            raise ConfigurationError(msg, key=key)
-    return val
-
-
-def ensure_dict(val: dict[str, str] | None, key: str) -> dict[str, str]:
-    if val is None:
-        return {}
-    if not isinstance(val, dict):
-        msg = f'Field "{key}" has an invalid type, expecting a dictionary of strings (got "{val}")'
-        raise ConfigurationError(msg, key=key)
-    for subkey, item in val.items():
-        if not isinstance(item, str):
-            msg = f'Field "{key}.{subkey}" has an invalid type, expecting a string (got "{item}")'
-            raise ConfigurationError(msg, key=f'{key}.{subkey}')
-    return val
-
-
-def ensure_people(
-    val: Sequence[ContactTable], key: str
-) -> list[tuple[str, str | None]]:
-    if not (
-        isinstance(val, list)
-        and all(isinstance(x, dict) for x in val)
-        and all(
-            isinstance(item, str)
-            for items in [_dict.values() for _dict in val]
-            for item in items
-        )
-    ):
-        msg = (
-            f'Field "{key}" has an invalid type, expecting a list of '
-            f'dictionaries containing the "name" and/or "email" keys (got "{val}")'
-        )
-        raise ConfigurationError(msg, key=key)
-    return [(entry.get('name', 'Unknown'), entry.get('email')) for entry in val]
-
-
-def get_license(
-    project: ProjectTable, project_dir: pathlib.Path
-) -> License | str | None:
-    val = project.get('license')
-    if val is None:
-        return None
-    if isinstance(val, str):
         return val
 
-    if isinstance(val, dict):
-        _license = ensure_dict(val, 'project.license')  # type: ignore[arg-type]
-    else:
-        msg = f'Field "project.license" has an invalid type, expecting a string or dictionary of strings (got "{val}")'
-        raise ConfigurationError(msg)
+    def ensure_dict(self, val: dict[str, str], key: str) -> dict[str, str] | None:
+        if not isinstance(val, dict):
+            msg = f'Field "{key}" has an invalid type, expecting a dictionary of strings (got "{val}")'
+            self.config_error(msg, key=key)
+            return None
+        for subkey, item in val.items():
+            if not isinstance(item, str):
+                msg = f'Field "{key}.{subkey}" has an invalid type, expecting a string (got "{item}")'
+                self.config_error(msg, key=f'{key}.{subkey}')
+                return None
+        return val
 
-    for field in _license:
-        if field not in ('file', 'text'):
-            msg = f'Unexpected field "project.license.{field}"'
-            raise ConfigurationError(msg, key=f'project.license.{field}')
+    def ensure_people(
+        self, val: Sequence[ContactTable], key: str
+    ) -> list[tuple[str, str | None]]:
+        if not (
+            isinstance(val, list)
+            and all(isinstance(x, dict) for x in val)
+            and all(
+                isinstance(item, str)
+                for items in [_dict.values() for _dict in val]
+                for item in items
+            )
+        ):
+            msg = (
+                f'Field "{key}" has an invalid type, expecting a list of '
+                f'dictionaries containing the "name" and/or "email" keys (got "{val}")'
+            )
+            self.config_error(msg, key=key)
+            return []
+        return [(entry.get('name', 'Unknown'), entry.get('email')) for entry in val]
 
-    file: pathlib.Path | None = None
-    filename = _license.get('file')
-    text = _license.get('text')
+    def get_license(
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> License | str | None:
+        val = project.get('license')
+        if val is None:
+            return None
+        if isinstance(val, str):
+            return val
 
-    if (filename and text) or (not filename and not text):
-        msg = f'Invalid "project.license" value, expecting either "file" or "text" (got "{_license}")'
-        raise ConfigurationError(msg, key='project.license')
-
-    if filename:
-        file = project_dir.joinpath(filename)
-        if not file.is_file():
-            msg = f'License file not found ("{filename}")'
-            raise ConfigurationError(msg, key='project.license.file')
-        text = file.read_text(encoding='utf-8')
-
-    assert text is not None
-    return License(text, file)
-
-
-def get_license_files(
-    project: ProjectTable, project_dir: pathlib.Path
-) -> list[pathlib.Path] | None:
-    license_files = project.get('license-files')
-    if license_files is None:
-        return None
-    ensure_list(license_files, 'project.license-files')
-
-    return list(_get_files_from_globs(project_dir, license_files))
-
-
-def get_readme(project: ProjectTable, project_dir: pathlib.Path) -> Readme | None:  # noqa: C901
-    if 'readme' not in project:
-        return None
-
-    filename: str | None
-    file: pathlib.Path | None = None
-    text: str | None
-    content_type: str | None
-
-    readme = project['readme']
-    if isinstance(readme, str):
-        # readme is a file
-        text = None
-        filename = readme
-        if filename.endswith('.md'):
-            content_type = 'text/markdown'
-        elif filename.endswith('.rst'):
-            content_type = 'text/x-rst'
+        if isinstance(val, dict):
+            _license = self.ensure_dict(val, 'project.license')  # type: ignore[arg-type]
+            if _license is None:
+                return None
         else:
-            msg = f'Could not infer content type for readme file "{filename}"'
-            raise ConfigurationError(msg, key='project.readme')
-    elif isinstance(readme, dict):
-        # readme is a dict containing either 'file' or 'text', and content-type
-        for field in readme:
-            if field not in ('content-type', 'file', 'text'):
-                msg = f'Unexpected field "project.readme.{field}"'
-                raise ConfigurationError(msg, key=f'project.readme.{field}')
-        content_type = ensure_str(
-            readme.get('content-type'), 'project.readme.content-type'
-        )
-        filename = ensure_str(readme.get('file'), 'project.readme.file')
-        text = ensure_str(readme.get('text'), 'project.readme.text')
+            msg = f'Field "project.license" has an invalid type, expecting a string or dictionary of strings (got "{val}")'
+            self.config_error(msg, key='project.license')
+            return None
+
+        for field in _license:
+            if field not in ('file', 'text'):
+                msg = f'Unexpected field "project.license.{field}"'
+                self.config_error(msg, key=f'project.license.{field}')
+                return None
+
+        file: pathlib.Path | None = None
+        filename = _license.get('file')
+        text = _license.get('text')
+
         if (filename and text) or (not filename and not text):
-            msg = f'Invalid "project.readme" value, expecting either "file" or "text" (got "{readme}")'
-            raise ConfigurationError(msg, key='project.readme')
-        if not content_type:
-            msg = 'Field "project.readme.content-type" missing'
-            raise ConfigurationError(msg, key='project.readme.content-type')
-    else:
-        msg = (
-            f'Field "project.readme" has an invalid type, expecting either, '
-            f'a string or dictionary of strings (got "{readme}")'
-        )
-        raise ConfigurationError(msg, key='project.readme')
+            msg = f'Invalid "project.license" value, expecting either "file" or "text" (got "{_license}")'
+            self.config_error(msg, key='project.license')
+            return None
 
-    if filename:
-        file = project_dir.joinpath(filename)
-        if not file.is_file():
-            msg = f'Readme file not found ("{filename}")'
-            raise ConfigurationError(msg, key='project.readme.file')
-        text = file.read_text(encoding='utf-8')
+        if filename:
+            file = project_dir.joinpath(filename)
+            if not file.is_file():
+                msg = f'License file not found ("{filename}")'
+                self.config_error(msg, key='project.license.file')
+                return None
+            text = file.read_text(encoding='utf-8')
 
-    assert text is not None
-    return Readme(text, file, content_type)
+        assert text is not None
+        return License(text, file)
 
+    def get_license_files(
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> list[pathlib.Path] | None:
+        license_files = project.get('license-files')
+        if license_files is None:
+            return None
+        if self.ensure_list(license_files, 'project.license-files') is None:
+            return None
 
-def get_dependencies(project: ProjectTable) -> list[Requirement]:
-    requirement_strings = (
-        ensure_list(project.get('dependencies'), 'project.dependencies') or []
-    )
+        return list(self._get_files_from_globs(project_dir, license_files))
 
-    requirements: list[Requirement] = []
-    for req in requirement_strings:
-        try:
-            requirements.append(packaging.requirements.Requirement(req))
-        except packaging.requirements.InvalidRequirement as e:
-            msg = (
-                'Field "project.dependencies" contains an invalid PEP 508 '
-                f'requirement string "{req}" ("{e}")'
-            )
-            raise ConfigurationError(msg) from None
-    return requirements
+    def get_readme(  # noqa: C901
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> Readme | None:
+        if 'readme' not in project:
+            return None
 
+        filename: str | None = None
+        file: pathlib.Path | None = None
+        text: str | None = None
+        content_type: str | None = None
 
-def get_optional_dependencies(
-    project: ProjectTable,
-) -> dict[str, list[Requirement]]:
-    val = project.get('optional-dependencies')
-    if not val:
-        return {}
+        readme = project['readme']
+        if isinstance(readme, str):
+            # readme is a file
+            text = None
+            filename = readme
+            if filename.endswith('.md'):
+                content_type = 'text/markdown'
+            elif filename.endswith('.rst'):
+                content_type = 'text/x-rst'
+            else:
+                msg = f'Could not infer content type for readme file "{filename}"'
+                self.config_error(msg, key='project.readme')
+                return None
+        elif isinstance(readme, dict):
+            # readme is a dict containing either 'file' or 'text', and content-type
+            for field in readme:
+                if field not in ('content-type', 'file', 'text'):
+                    msg = f'Unexpected field "project.readme.{field}"'
+                    self.config_error(msg, key=f'project.readme.{field}')
+                    return None
 
-    requirements_dict: dict[str, list[Requirement]] = {}
-    if not isinstance(val, dict):
-        msg = (
-            'Field "project.optional-dependencies" has an invalid type, expecting a '
-            f'dictionary of PEP 508 requirement strings (got "{val}")'
-        )
-        raise ConfigurationError(msg)
-    for extra, requirements in val.copy().items():
-        assert isinstance(extra, str)
-        if not isinstance(requirements, list):
-            msg = (
-                f'Field "project.optional-dependencies.{extra}" has an invalid type, expecting a '
-                f'dictionary PEP 508 requirement strings (got "{requirements}")'
-            )
-            raise ConfigurationError(msg)
-        requirements_dict[extra] = []
-        for req in requirements:
-            if not isinstance(req, str):
-                msg = (
-                    f'Field "project.optional-dependencies.{extra}" has an invalid type, '
-                    f'expecting a PEP 508 requirement string (got "{req}")'
+            content_type_raw = readme.get('content-type')
+            if content_type_raw is not None:
+                content_type = self.ensure_str(
+                    content_type_raw, 'project.readme.content-type'
                 )
-                raise ConfigurationError(msg)
+                if content_type is None:
+                    return None
+            filename_raw = readme.get('file')
+            if filename_raw is not None:
+                filename = self.ensure_str(filename_raw, 'project.readme.file')
+                if filename is None:
+                    return None
+
+            text_raw = readme.get('text')
+            if text_raw is not None:
+                text = self.ensure_str(text_raw, 'project.readme.text')
+                if text is None:
+                    return None
+
+            if (filename and text) or (not filename and not text):
+                msg = f'Invalid "project.readme" value, expecting either "file" or "text" (got "{readme}")'
+                self.config_error(msg, key='project.readme')
+                return None
+            if not content_type:
+                msg = 'Field "project.readme.content-type" missing'
+                self.config_error(msg, key='project.readme.content-type')
+                return None
+        else:
+            msg = (
+                f'Field "project.readme" has an invalid type, expecting either, '
+                f'a string or dictionary of strings (got "{readme}")'
+            )
+            self.config_error(msg, key='project.readme')
+            return None
+
+        if filename:
+            file = project_dir.joinpath(filename)
+            if not file.is_file():
+                msg = f'Readme file not found ("{filename}")'
+                self.config_error(msg, key='project.readme.file')
+                return None
+            text = file.read_text(encoding='utf-8')
+
+        assert text is not None
+        return Readme(text, file, content_type)
+
+    def get_dependencies(self, project: ProjectTable) -> list[Requirement]:
+        requirement_strings: list[str] | None = None
+        requirement_strings_raw = project.get('dependencies')
+        if requirement_strings_raw is not None:
+            requirement_strings = self.ensure_list(
+                requirement_strings_raw, 'project.dependencies'
+            )
+        if requirement_strings is None:
+            return []
+
+        requirements: list[Requirement] = []
+        for req in requirement_strings:
             try:
-                requirements_dict[extra].append(packaging.requirements.Requirement(req))
+                requirements.append(packaging.requirements.Requirement(req))
             except packaging.requirements.InvalidRequirement as e:
                 msg = (
-                    f'Field "project.optional-dependencies.{extra}" contains '
-                    f'an invalid PEP 508 requirement string "{req}" ("{e}")'
+                    'Field "project.dependencies" contains an invalid PEP 508 '
+                    f'requirement string "{req}" ("{e}")'
                 )
-                raise ConfigurationError(msg) from None
-    return dict(requirements_dict)
+                self.config_error(msg, key='project.dependencies')
+                return []
+        return requirements
 
+    def get_optional_dependencies(
+        self,
+        project: ProjectTable,
+    ) -> dict[str, list[Requirement]]:
+        val = project.get('optional-dependencies')
+        if not val:
+            return {}
 
-def get_entrypoints(project: ProjectTable) -> dict[str, dict[str, str]]:
-    val = project.get('entry-points', None)
-    if val is None:
-        return {}
-    if not isinstance(val, dict):
-        msg = (
-            'Field "project.entry-points" has an invalid type, expecting a '
-            f'dictionary of entrypoint sections (got "{val}")'
-        )
-        raise ConfigurationError(msg)
-    for section, entrypoints in val.items():
-        assert isinstance(section, str)
-        if not re.match(r'^\w+(\.\w+)*$', section):
+        requirements_dict: dict[str, list[Requirement]] = {}
+        if not isinstance(val, dict):
             msg = (
-                'Field "project.entry-points" has an invalid value, expecting a name '
-                f'containing only alphanumeric, underscore, or dot characters (got "{section}")'
+                'Field "project.optional-dependencies" has an invalid type, expecting a '
+                f'dictionary of PEP 508 requirement strings (got "{val}")'
             )
-            raise ConfigurationError(msg)
-        if not isinstance(entrypoints, dict):
-            msg = (
-                f'Field "project.entry-points.{section}" has an invalid type, expecting a '
-                f'dictionary of entrypoints (got "{entrypoints}")'
-            )
-            raise ConfigurationError(msg)
-        for name, entrypoint in entrypoints.items():
-            assert isinstance(name, str)
-            if not isinstance(entrypoint, str):
+            self.config_error(msg, key='project.optional-dependencies')
+            return {}
+        for extra, requirements in val.copy().items():
+            assert isinstance(extra, str)
+            if not isinstance(requirements, list):
                 msg = (
-                    f'Field "project.entry-points.{section}.{name}" has an invalid type, '
-                    f'expecting a string (got "{entrypoint}")'
+                    f'Field "project.optional-dependencies.{extra}" has an invalid type, expecting a '
+                    f'dictionary PEP 508 requirement strings (got "{requirements}")'
                 )
-                raise ConfigurationError(msg)
-    return val
+                self.config_error(msg, key=f'project.optional-dependencies.{extra}')
+                return {}
+            requirements_dict[extra] = []
+            for req in requirements:
+                if not isinstance(req, str):
+                    msg = (
+                        f'Field "project.optional-dependencies.{extra}" has an invalid type, '
+                        f'expecting a PEP 508 requirement string (got "{req}")'
+                    )
+                    self.config_error(msg, key=f'project.optional-dependencies.{extra}')
+                    return {}
+                try:
+                    requirements_dict[extra].append(
+                        packaging.requirements.Requirement(req)
+                    )
+                except packaging.requirements.InvalidRequirement as e:
+                    msg = (
+                        f'Field "project.optional-dependencies.{extra}" contains '
+                        f'an invalid PEP 508 requirement string "{req}" ("{e}")'
+                    )
+                    self.config_error(msg, key=f'project.optional-dependencies.{extra}')
+                    return {}
+        return dict(requirements_dict)
 
+    def get_entrypoints(self, project: ProjectTable) -> dict[str, dict[str, str]]:
+        val = project.get('entry-points', None)
+        if val is None:
+            return {}
+        if not isinstance(val, dict):
+            msg = (
+                'Field "project.entry-points" has an invalid type, expecting a '
+                f'dictionary of entrypoint sections (got "{val}")'
+            )
+            self.config_error(msg, key='project.entry-points')
+            return {}
+        for section, entrypoints in val.items():
+            assert isinstance(section, str)
+            if not re.match(r'^\w+(\.\w+)*$', section):
+                msg = (
+                    'Field "project.entry-points" has an invalid value, expecting a name '
+                    f'containing only alphanumeric, underscore, or dot characters (got "{section}")'
+                )
+                self.config_error(msg, key='project.entry-points')
+                return {}
+            if not isinstance(entrypoints, dict):
+                msg = (
+                    f'Field "project.entry-points.{section}" has an invalid type, expecting a '
+                    f'dictionary of entrypoints (got "{entrypoints}")'
+                )
+                self.config_error(msg, key=f'project.entry-points.{section}')
+                return {}
+            for name, entrypoint in entrypoints.items():
+                assert isinstance(name, str)
+                if not isinstance(entrypoint, str):
+                    msg = (
+                        f'Field "project.entry-points.{section}.{name}" has an invalid type, '
+                        f'expecting a string (got "{entrypoint}")'
+                    )
+                    self.config_error(msg, key=f'project.entry-points.{section}.{name}')
+                    return {}
+        return val
 
-def get_dynamic(project: ProjectTable) -> list[str]:
-    dynamic: list[str] = project.get('dynamic', [])  # type: ignore[assignment]
+    def get_dynamic(self, project: ProjectTable) -> list[str]:
+        dynamic: list[str] = project.get('dynamic', [])  # type: ignore[assignment]
 
-    ensure_list(dynamic, 'project.dynamic')
+        self.ensure_list(dynamic, 'project.dynamic')
 
-    if 'name' in dynamic:
-        msg = 'Unsupported field "name" in "project.dynamic"'
-        raise ConfigurationError(msg)
+        if 'name' in dynamic:
+            msg = 'Unsupported field "name" in "project.dynamic"'
+            self.config_error(msg, key='project.dynamic')
+            return []
 
-    return dynamic
+        return dynamic
 
-
-def _get_files_from_globs(
-    project_dir: pathlib.Path, globs: Iterable[str]
-) -> Generator[pathlib.Path, None, None]:
-    for glob in globs:
-        if glob.startswith(('..', '/')):
-            msg = f'"{glob}" is an invalid "project.license-files" glob: the pattern must match files within the project directory'
-            raise ConfigurationError(msg)
-        files = [f for f in project_dir.glob(glob) if f.is_file()]
-        if not files:
-            msg = f'Every pattern in "project.license-files" must match at least one file: "{glob}" did not match any'
-            raise ConfigurationError(msg)
-        for f in files:
-            yield f.relative_to(project_dir)
+    def _get_files_from_globs(
+        self, project_dir: pathlib.Path, globs: Iterable[str]
+    ) -> Generator[pathlib.Path, None, None]:
+        for glob in globs:
+            if glob.startswith(('..', '/')):
+                msg = f'"{glob}" is an invalid "project.license-files" glob: the pattern must match files within the project directory'
+                self.config_error(msg)
+                break
+            files = [f for f in project_dir.glob(glob) if f.is_file()]
+            if not files:
+                msg = f'Every pattern in "project.license-files" must match at least one file: "{glob}" did not match any'
+                self.config_error(msg)
+                break
+            for f in files:
+                yield f.relative_to(project_dir)


### PR DESCRIPTION
Close #45. Adds an `all_errors` parameter that causes all errors to be collected and shown in a ExceptionGroup. The output is a bit ugly for \<3.11, but no dependency is required. A build backend can use the backport by replacing `pyproject_metadata.errors.ExceptionGroup`.

If we submit to packaging, this would be the default there #140. And if we do, then I'd be very likely to want the back port here eventually, since a user can use packaging if they need minimal deps. Though, "eventually" probably would be around the time 3.11 becomes the minimum... so yeah, might not happen.

I've also added quite a few missing `key=` params as well as provided better descriptions in a few cases.