### PR TITLE
chore: remove PLR09 checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ extend-select = [
   "NPY",         # NumPy specific rules
   "PD",          # pandas-vet
 ]
-ignore = ["ISC001"]  # conflicts with formatter
+ignore = [
+  "ISC001",  # conflicts with formatter
+  "PLR09",  # Design related (too many X)
+]
 isort.lines-after-imports = 2
 isort.lines-between-types = 1
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -408,7 +408,7 @@ class StandardMetadata:
         self._write_metadata(smart_message)
         return message
 
-    def _write_metadata(  # noqa: PLR0912 C901
+    def _write_metadata(  # noqa: C901
         self, smart_message: _SmartMessageSetter | _JSonMessageSetter
     ) -> None:
         self.validate(warn=False)

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -147,7 +147,7 @@ def get_license_files(
     return list(_get_files_from_globs(project_dir, license_files))
 
 
-def get_readme(project: ProjectTable, project_dir: pathlib.Path) -> Readme | None:  # noqa: C901, PLR0912
+def get_readme(project: ProjectTable, project_dir: pathlib.Path) -> Readme | None:  # noqa: C901
     if 'readme' not in project:
         return None
 


### PR DESCRIPTION
These are just annoying to skip, and aren't really helping that much. There's also a nearly identical C check anyway.
