### PR TITLE
refactor: validate all extra keys, support workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,13 @@ just `ExceptionGroup` on Python 3.11+).
 
 ## Validating extra fields
 
-By default, a warning will be issued for extra fields at the top level, in
-build-system, and in the project table. If you want to make these errors, pass
-`validate=Validate.EXTRA_KEYS` in `from_pyproject`. You can also pass
-`warn=Validate.NONE` to disable the warnings instead.  For fine-grained control,
-you can pass `Validate.TOP_LEVEL` to only validate top-level fields,
-`Validate.BUILD_SYSTEM` to only validate build-system fields, and
-`Validate.PROJECT` to only validate project fields, or any `|` combination of
-these.
+By default, a warning (`pyproject_metadata.errors.ExtraKeyWarning`) will be
+issued for extra fields at the top level, in build-system, and in the project
+table. If you want to make these errors, pass `validate=Validate.EXTRA_KEYS` in
+`from_pyproject`. For fine-grained control, you can pass `Validate.TOP_LEVEL` to
+only validate top-level fields, `Validate.BUILD_SYSTEM` to only validate
+build-system fields, and `Validate.PROJECT` to only validate project fields, or
+any `|` combination of these.
 
 ## Validating classifiers
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ just `ExceptionGroup` on Python 3.11+).
 
 By default, a warning (`pyproject_metadata.errors.ExtraKeyWarning`) will be
 issued for extra fields at the top level, in build-system, and in the project
-table. If you want to make these errors, pass `validate=Validate.EXTRA_KEYS` in
-`from_pyproject`. For fine-grained control, you can pass `Validate.TOP_LEVEL` to
-only validate top-level fields, `Validate.BUILD_SYSTEM` to only validate
-build-system fields, and `Validate.PROJECT` to only validate project fields, or
-any `|` combination of these.
+table. If you want to make these errors, pass `allow_extra_keys=False` in
+`from_pyproject`. Passing `True` instead avoid the check entirely. If you
+want to only validate the `project` table, you can pass
+`{"project": pyproject.get("project", None)}` instead of the full `pyproject.toml`.
 
 ## Validating classifiers
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ folder, preserving the original source structure.
 
 Pyproject-metadata supports dynamic metadata. To use it, specify your METADATA fields in `dynamic_metadata`. If you want to convert `pyproject.toml` field names to METADATA field(s), use `pyproject_metadata.pyproject_to_metadata("field-name")`, which will return a frozenset of metadata names that are touched by that field.
 
-
 ## Adding extra fields
 
 You can add extra fields to the Message returned by `to_rfc822()`, as long as they are valid metadata entries.
@@ -68,6 +67,17 @@ You can use the `all_errors` argument to `from_pyproject` to show all errors in
 the metadata parse at once, instead of raising an exception on the first one.
 The exception type will be `pyproject_metadata.errors.ExceptionGroup` (which is
 just `ExceptionGroup` on Python 3.11+).
+
+## Validating extra fields
+
+By default, a warning will be issued for extra fields at the top level, in
+build-system, and in the project table. If you want to make these errors, pass
+`validate=Validate.EXTRA_KEYS` in `from_pyproject`. You can also pass
+`warn=Validate.NONE` to disable the warnings instead.  For fine-grained control,
+you can pass `Validate.TOP_LEVEL` to only validate top-level fields,
+`Validate.BUILD_SYSTEM` to only validate build-system fields, and
+`Validate.PROJECT` to only validate project fields, or any `|` combination of
+these.
 
 ## Validating classifiers
 

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -73,15 +73,6 @@ class ErrorCollector:
         if self.errors:
             raise ExceptionGroup(msg, self.errors)
 
-    def reraise(self, err: Exception) -> None:
-        """
-        Take an existing error and raise it, or add it to the error list.
-        """
-        if self.collect_errors:
-            self.errors.append(err)
-        else:
-            raise err from None
-
     @contextlib.contextmanager
     def collect(self) -> typing.Generator[None, None, None]:
         if self.collect_errors:

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -15,6 +15,7 @@ __all__ = [
     'ConfigurationWarning',
     'ExceptionGroup',
     'ErrorCollector',
+    'ExtraKeyWarning',
 ]
 
 
@@ -36,6 +37,10 @@ class ConfigurationError(Exception):
 
 class ConfigurationWarning(UserWarning):
     """Warnings about backend metadata."""
+
+
+class ExtraKeyWarning(ConfigurationWarning):
+    """Warning about an extra key in the backend metadata."""
 
 
 if sys.version_info >= (3, 11):

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -73,6 +73,15 @@ class ErrorCollector:
         if self.errors:
             raise ExceptionGroup(msg, self.errors)
 
+    def reraise(self, err: Exception) -> None:
+        """
+        Take an existing error and raise it, or add it to the error list.
+        """
+        if self.collect_errors:
+            self.errors.append(err)
+        else:
+            raise err from None
+
     @contextlib.contextmanager
     def collect(self) -> typing.Generator[None, None, None]:
         if self.collect_errors:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -722,7 +722,7 @@ def test_load(
     else:
         with warnings.catch_warnings():
             warnings.simplefilter(
-                action='ignore', category=pyproject_metadata.ConfigurationWarning
+                action='ignore', category=pyproject_metadata.errors.ConfigurationWarning
             )
             with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
                 pyproject_metadata.StandardMetadata.from_pyproject(
@@ -828,7 +828,7 @@ def test_load_multierror(
     else:
         with warnings.catch_warnings():
             warnings.simplefilter(
-                action='ignore', category=pyproject_metadata.ConfigurationWarning
+                action='ignore', category=pyproject_metadata.errors.ConfigurationWarning
             )
             with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
                 pyproject_metadata.StandardMetadata.from_pyproject(
@@ -911,7 +911,9 @@ def test_load_with_metadata_version_warnings(
     data: str, error: str, metadata_version: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(DIR / 'packages/full-metadata')
-    with pytest.warns(pyproject_metadata.ConfigurationWarning, match=re.escape(error)):
+    with pytest.warns(
+        pyproject_metadata.errors.ConfigurationWarning, match=re.escape(error)
+    ):
         pyproject_metadata.StandardMetadata.from_pyproject(
             tomllib.loads(textwrap.dedent(data)), metadata_version=metadata_version
         )
@@ -1395,7 +1397,7 @@ def test_modify_dynamic() -> None:
 
 def test_missing_keys_project_warns() -> None:
     with pytest.warns(
-        pyproject_metadata.ConfigurationWarning,
+        pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in "project": "not-real-key"'),
     ):
         pyproject_metadata.StandardMetadata.from_pyproject(
@@ -1411,7 +1413,7 @@ def test_missing_keys_project_warns() -> None:
 
 def test_missing_keys_top_level_warns() -> None:
     with pytest.warns(
-        pyproject_metadata.ConfigurationWarning,
+        pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in pyproject.toml: "not-real-key"'),
     ):
         pyproject_metadata.StandardMetadata.from_pyproject(
@@ -1427,7 +1429,7 @@ def test_missing_keys_top_level_warns() -> None:
 
 def test_missing_keys_build_system_warns() -> None:
     with pytest.warns(
-        pyproject_metadata.ConfigurationWarning,
+        pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in "build-system": "not-real-key"'),
     ):
         pyproject_metadata.StandardMetadata.from_pyproject(
@@ -1441,15 +1443,6 @@ def test_missing_keys_build_system_warns() -> None:
                 },
             }
         )
-
-
-def test_missing_keys_okay() -> None:
-    pyproject_metadata.StandardMetadata.from_pyproject(
-        {
-            'project': {'name': 'example', 'version': '1.2.3', 'not-real-key': True},
-        },
-        warn=pyproject_metadata.Validate.NONE,
-    )
 
 
 def test_extra_top_level() -> None:
@@ -1507,7 +1500,7 @@ def test_extra_build_system() -> None:
 
 def test_multiline_description_warns() -> None:
     with pytest.warns(
-        pyproject_metadata.ConfigurationWarning,
+        pyproject_metadata.errors.ConfigurationWarning,
         match=re.escape(
             'The one-line summary "project.description" should not contain more than one line. Readers might merge or truncate newlines.'
         ),

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -717,7 +717,7 @@ def test_load(
         ):
             pyproject_metadata.StandardMetadata.from_pyproject(
                 tomllib.loads(textwrap.dedent(data)),
-                validate=pyproject_metadata.Validate.EXTRA_KEYS,
+                allow_extra_keys=False,
             )
     else:
         with warnings.catch_warnings():
@@ -727,7 +727,7 @@ def test_load(
             with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
                 pyproject_metadata.StandardMetadata.from_pyproject(
                     tomllib.loads(textwrap.dedent(data)),
-                    validate=pyproject_metadata.Validate.EXTRA_KEYS,
+                    allow_extra_keys=False,
                     all_errors=True,
                 )
         exceptions = execinfo.value.exceptions
@@ -823,7 +823,7 @@ def test_load_multierror(
         ):
             pyproject_metadata.StandardMetadata.from_pyproject(
                 tomllib.loads(textwrap.dedent(data)),
-                validate=pyproject_metadata.Validate.EXTRA_KEYS,
+                allow_extra_keys=False,
             )
     else:
         with warnings.catch_warnings():
@@ -833,7 +833,7 @@ def test_load_multierror(
             with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
                 pyproject_metadata.StandardMetadata.from_pyproject(
                     tomllib.loads(textwrap.dedent(data)),
-                    validate=pyproject_metadata.Validate.EXTRA_KEYS,
+                    allow_extra_keys=False,
                     all_errors=True,
                 )
         exceptions = execinfo.value.exceptions
@@ -1395,7 +1395,16 @@ def test_modify_dynamic() -> None:
         metadata.version = packaging.version.Version('1.2.3')
 
 
-def test_missing_keys_project_warns() -> None:
+def test_extra_keys_okay() -> None:
+    pyproject_metadata.StandardMetadata.from_pyproject(
+        {
+            'project': {'name': 'example', 'version': '1.2.3', 'not-real-key': True},
+        },
+        allow_extra_keys=True,
+    )
+
+
+def test_extra_keys_project_warns() -> None:
     with pytest.warns(
         pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in "project": "not-real-key"'),
@@ -1411,7 +1420,7 @@ def test_missing_keys_project_warns() -> None:
         )
 
 
-def test_missing_keys_top_level_warns() -> None:
+def test_extra_keys_top_level_warns() -> None:
     with pytest.warns(
         pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in pyproject.toml: "not-real-key"'),
@@ -1427,7 +1436,7 @@ def test_missing_keys_top_level_warns() -> None:
         )
 
 
-def test_missing_keys_build_system_warns() -> None:
+def test_extra_keys_build_system_warns() -> None:
     with pytest.warns(
         pyproject_metadata.errors.ExtraKeyWarning,
         match=re.escape('Extra keys present in "build-system": "not-real-key"'),
@@ -1450,7 +1459,7 @@ def test_extra_top_level() -> None:
         {
             'project': {'name': 'example', 'version': '1.2.3'},
         },
-        validate=pyproject_metadata.Validate.TOP_LEVEL,
+        allow_extra_keys=False,
     )
     with pytest.raises(
         pyproject_metadata.ConfigurationError,
@@ -1464,7 +1473,7 @@ def test_extra_top_level() -> None:
                 'not-real': {},
                 'also-not-real': {},
             },
-            validate=pyproject_metadata.Validate.TOP_LEVEL,
+            allow_extra_keys=False,
         )
 
 
@@ -1478,7 +1487,7 @@ def test_extra_build_system() -> None:
             },
             'project': {'name': 'example', 'version': '1.2.3'},
         },
-        validate=pyproject_metadata.Validate.BUILD_SYSTEM,
+        allow_extra_keys=False,
     )
     with pytest.raises(
         pyproject_metadata.ConfigurationError,
@@ -1494,7 +1503,7 @@ def test_extra_build_system() -> None:
                 },
                 'project': {'name': 'example', 'version': '1.2.3'},
             },
-            validate=pyproject_metadata.Validate.BUILD_SYSTEM,
+            allow_extra_keys=False,
         )
 
 


### PR DESCRIPTION
This removes the validate functions introduced in a previous beta, and instead expands the scope of `allow_extra_keys` to include the main and build-system tables. You can workaround it with a simple trick given in the documentation if you don't want these validated (also, remember the default is a warning).