### PR TITLE
refactor: validate -> extras functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ the metadata parse at once, instead of raising an exception on the first one.
 The exception type will be `pyproject_metadata.errors.ExceptionGroup` (which is
 just `ExceptionGroup` on Python 3.11+).
 
+
+## Validating extra fields
+
+By default, a warning (`pyproject_metadata.errors.ExtraKeyWarning`) will be
+issued for extra fields at the project table. You can pass `allow_extra_keys=`
+to either avoid the check (`True`) or hard error (`False`). If you want to
+detect extra keys, you can get them with `pyproject_metadata.extra_top_level`
+and `pyproject_metadata.extra_build_sytem`.
+
 ## Validating classifiers
 
 If you want to validate classifiers, then install the `trove_classifiers` library (the canonical source for classifiers), and run:

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -350,12 +350,15 @@ class StandardMetadata:
         if raw_version is not None:
             version_string = pyproject.ensure_str(raw_version, 'project.version')
             if version_string is not None:
-                with pyproject.collect():
+                try:
                     version = (
                         packaging.version.Version(version_string)
                         if version_string
                         else None
                     )
+                except packaging.version.InvalidVersion:
+                    msg = f'Invalid "project.version" value, expecting a valid PEP 440 version (got "{version_string}")'
+                    pyproject.config_error(msg, key='project.version')
         elif 'version' not in dynamic:
             msg = 'Field "project.version" missing and "version" not specified in "project.dynamic"'
             pyproject.config_error(msg, key='version')
@@ -377,10 +380,13 @@ class StandardMetadata:
                 requires_python_raw, 'project.requires-python'
             )
             if requires_python_string is not None:
-                with pyproject.collect():
+                try:
                     requires_python = packaging.specifiers.SpecifierSet(
                         requires_python_string
                     )
+                except packaging.specifiers.InvalidSpecifier:
+                    msg = f'Invalid "project.requires-python" value, expecting a valid specifier set (got "{requires_python_string}")'
+                    pyproject.config_error(msg, key='project.requires-python')
 
         self = None
         with pyproject.collect():

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -6,9 +6,6 @@ import dataclasses
 import sys
 import typing
 
-import packaging.specifiers
-import packaging.version
-
 
 __all__ = [
     'ConfigurationError',
@@ -78,12 +75,6 @@ class ErrorCollector:
         if self.collect_errors:
             try:
                 yield
-            except (
-                ConfigurationError,
-                packaging.version.InvalidVersion,
-                packaging.specifiers.InvalidSpecifier,
-            ) as error:
-                self.errors.append(error)
             except ExceptionGroup as error:
                 self.errors.extend(error.exceptions)
         else:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1419,27 +1419,23 @@ def test_missing_keys_okay() -> None:
 
 
 def test_extra_top_level() -> None:
-    pyproject_metadata.validate_top_level(
+    assert not pyproject_metadata.extras_top_level(
         {
             'project': {},
         }
     )
-    with pytest.raises(
-        pyproject_metadata.ConfigurationError,
-        match=re.escape(
-            'Extra keys present in pyproject.toml: "also-not-real", "not-real"'
-        ),
-    ):
-        pyproject_metadata.validate_top_level(
-            {
-                'not-real': {},
-                'also-not-real': {},
-            }
-        )
+    assert {'also-not-real', 'not-real'} == pyproject_metadata.extras_top_level(
+        {
+            'not-real': {},
+            'also-not-real': {},
+            'project': {},
+            'build-system': {},
+        }
+    )
 
 
 def test_extra_build_system() -> None:
-    pyproject_metadata.validate_build_system(
+    assert not pyproject_metadata.extras_build_system(
         {
             'build-system': {
                 'build-backend': 'one',
@@ -1448,20 +1444,14 @@ def test_extra_build_system() -> None:
             },
         }
     )
-    with pytest.raises(
-        pyproject_metadata.ConfigurationError,
-        match=re.escape(
-            'Extra keys present in "build-system": "also-not-real", "not-real"'
-        ),
-    ):
-        pyproject_metadata.validate_build_system(
-            {
-                'build-system': {
-                    'not-real': {},
-                    'also-not-real': {},
-                }
+    assert {'also-not-real', 'not-real'} == pyproject_metadata.extras_build_system(
+        {
+            'build-system': {
+                'not-real': {},
+                'also-not-real': {},
             }
-        )
+        }
+    )
 
 
 def test_multiline_description_warns() -> None:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -115,6 +115,15 @@ def all_errors(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) 
             """
                 [project]
                 name = 'test'
+                version = '0.1.0-extra'
+            """,
+            'Invalid "project.version" value, expecting a valid PEP 440 version (got "0.1.0-extra")',
+            id='Invalid version value',
+        ),
+        pytest.param(
+            """
+                [project]
+                name = 'test'
                 version = '0.1.0'
                 license = true
             """,
@@ -415,6 +424,16 @@ def all_errors(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) 
             """,
             'Field "project.requires-python" has an invalid type, expecting a string (got "True")',
             id='Invalid requires-python type',
+        ),
+        pytest.param(
+            """
+                [project]
+                name = 'test'
+                version = '0.1.0'
+                requires-python = '3.8'
+            """,
+            'Invalid "project.requires-python" value, expecting a valid specifier set (got "3.8")',
+            id='Invalid requires-python value',
         ),
         pytest.param(
             """


### PR DESCRIPTION
This feels like a simpler solution to #178. It just simplifies the "validate_*" functions to producing a set of extra fields, so the consumer can choose what to do with them. This also simplifies the implementation of allow_extra_keys, too.
