### PR TITLE
[v0.8] chore: release 0.8.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,6 @@ Changelog
 0.8.1 (07-10-2024)
 ==================
 
-Features:
-
 - Validate project name
 - Validate entrypoint group names
 - Correct typing for emails

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog
 +++++++++
 
+0.8.1 (07-10-2024)
+==================
+
+Features:
+
+- Validate project name
+- Validate entrypoint group names
+- Correct typing for emails
+- Add 3.13 to testing
+- Add ruff-format
+- Actions and dependabot
+- Generate GitHub attestations for releases
+- Add PyPI attestations
+- Fix coverage context
+
+
 0.8.0 (17-04-2024)
 ==================
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -32,7 +32,7 @@ import packaging.utils
 import packaging.version
 
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 KNOWN_METADATA_VERSIONS = {'2.1', '2.2', '2.3'}
 


### PR DESCRIPTION
Preparing for 0.8.1 while we wait for 0.9.0 to be evaluated by build backends. Getting that 3.13 classifier on Python 3.13.0 release day.