### PR TITLE
fix: support METADATA 2.4 being set explicilty & PEP 639

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ By default, a warning (`pyproject_metadata.errors.ExtraKeyWarning`) will be
 issued for extra fields at the project table. You can pass `allow_extra_keys=`
 to either avoid the check (`True`) or hard error (`False`). If you want to
 detect extra keys, you can get them with `pyproject_metadata.extra_top_level`
-and `pyproject_metadata.extra_build_sytem`.
+and `pyproject_metadata.extra_build_system`. It is recommended that build
+systems only warn on failures with these extra keys.
 
 ## Validating classifiers
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -586,6 +586,12 @@ class StandardMetadata:
         if self.license_files is not None:
             for license_file in sorted(set(self.license_files)):
                 smart_message["License-File"] = os.fspath(license_file.as_posix())
+        elif (
+            self.auto_metadata_version not in constants.PRE_SPDX_METADATA_VERSIONS
+            and isinstance(self.license, License)
+            and self.license.file
+        ):
+            smart_message["License-File"] = os.fspath(self.license.file.as_posix())
 
         for classifier in self.classifiers:
             smart_message["Classifier"] = classifier

--- a/tests/packages/fulltext_license/LICENSE.txt
+++ b/tests/packages/fulltext_license/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright © 2019 Filipe Laíns <filipe.lains@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I think this correctly handles the case when METADATA 2.4+ is set and old license settings are used.

I don't think the PEP is clear on what to do with License (see discussion in #202), so I'm leaving it alone, based on a comment on https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/124.
