### PR TITLE
revert: remove attribute locking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,15 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
+      - name: Prepare nox
+        run: pipx install nox
+
+      - name: Limit virtualenv on 3.7
+        if: matrix.python == '3.7'
+        run: pipx inject --force nox 'virtualenv<20.27.0'
+
       - name: Run tests
-        run: pipx run nox -s test-${{ matrix.python }}
+        run: nox -s test-${{ matrix.python }}
 
       - name: Send coverage report
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -49,13 +49,6 @@ A backend is also expected to copy entries from `project.licence_files`, which
 are paths relative to the project directory, into the `dist-info/licenses`
 folder, preserving the original source structure.
 
-## Modifying metadata
-
-By default, `StandardMetadata` metadata fields are immutable unless a field is
-listed in `dynaimc` (not to be confused with `dynamic_metadata`). If you want to
-modify fields that are not dynamic, you can use the `dataclasses.replace` /
-`copy.replace` (Python 3.13+) function.
-
 ## Dynamic Metadata (METADATA 2.2+)
 
 Pyproject-metadata supports dynamic metadata. To use it, specify your METADATA

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -126,7 +126,6 @@ class _SmartMessageSetter:
     reduce boilerplate.
 
     If a value is None, do nothing.
-    If a value contains a newline, indent it (may produce a warning in the future).
     """
 
     message: email.message.Message
@@ -252,22 +251,9 @@ class StandardMetadata:
     """
     If True, all errors will be collected and raised in an ExceptionGroup.
     """
-    _locked_metadata: bool = False
-    """
-    Internal flag to prevent setting non-dynamic fields after initialization.
-    """
 
     def __post_init__(self) -> None:
         self.validate()
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        if self._locked_metadata:
-            metadata_name = name.replace("_", "-")
-            locked_fields = constants.KNOWN_METADATA_FIELDS - set(self.dynamic)
-            if metadata_name in locked_fields:
-                msg = f"Field {name!r} is not dynamic"
-                raise AttributeError(msg)
-        super().__setattr__(name, value)
 
     @property
     def auto_metadata_version(self) -> str:
@@ -442,7 +428,6 @@ class StandardMetadata:
                 metadata_version=metadata_version,
                 all_errors=all_errors,
             )
-            self._locked_metadata = True
 
         pyproject.finalize("Failed to parse pyproject.toml")
         assert self is not None

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1455,10 +1455,7 @@ def test_modify_dynamic() -> None:
         }
     )
     metadata.requires_python = packaging.specifiers.SpecifierSet(">=3.12")
-    with pytest.raises(
-        AttributeError, match=re.escape("Field 'version' is not dynamic")
-    ):
-        metadata.version = packaging.version.Version("1.2.3")
+    metadata.version = packaging.version.Version("1.2.3")
 
 
 def test_missing_keys_warns() -> None:


### PR DESCRIPTION
If we do want to remove attribute locking for non-dynamic fields, this is what it would look like. It can get in the way in a few valid cases (see #202). Maybe it's better to just leave it up to the backends to check the dynamic array? They probably never want our error to surface, anyway, as it's always a backend error to hit this.

Another option is we could make it smarter, allowing normalization for some fields. I just think the new license field might be tricky to validate if it's just a normalization? Or maybe not?

Or we can leave it.