### PR TITLE
docs: prepare for 0.9.0rc1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.0 RC 1
+
+Changes since last beta:
+
+- Remove attribute locking
+- Fix for METADATA 2.4 being set and PEP 639 recommendation
+- Support PEP 735 in top level validation
+- Adjust URL handling to better match PEP 753
+
 ## 0.9.0 (WIP)
 
 This release adds PEP 639 support (METADATA 2.4), refactors the RFC messages,
@@ -11,7 +20,7 @@ Features:
 
 - Added PEP 639 support for SPDX license and license files, METADATA 2.4
 - Validate extra keys (warning, opt-in error)
-- Setting a non-dynamic field is an error
+- Functions to check top level and build-system (including PEP 735 support)
 - Add TypedDict's in new module for typing pyproject.toml dicts
 - `all_errors=True` causes `ExceptionGroup`'s to be emitted
 - Support METADATA 2.1+ JSON format with new `.as_json()` method
@@ -23,6 +32,7 @@ Fixes:
 - Warn on multiline Summary (`project.description`)
 - Improve locking for just metadata fields
 - Error on extra keys in author/maintainer
+- URL name stylization removed matching PEP 753
 
 Refactoring:
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -68,7 +68,7 @@ import packaging.specifiers
 import packaging.utils
 import packaging.version
 
-__version__ = "0.9.0b7"
+__version__ = "0.9.0rc1"
 
 __all__ = [
     "ConfigurationError",


### PR DESCRIPTION
I don't forsee any more changes before 0.9.0. I'll make sure this works in scikit-build-core, then will be ready for release!
