### PR TITLE
fix: min version of packaging was wrong in 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "packaging>=19.0",
+    "packaging>=23.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`InvalidName` was added in this version.
