### PR TITLE
chore: use dependency-groups, check minimums

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Run tests
         run: uv run noxfile.py -s test-${{ matrix.python }}
 
+      - name: Run minimum tests
+        run: uv run noxfile.py -s minimums-${{ matrix.python }}
+
       - name: Send coverage report
         uses: codecov/codecov-action@v5
         env:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,4 +11,5 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv run --group docs sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv run --group docs sphinx-build -T -b html -d docs/_build/doctrees -D
+      language=en docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,11 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
     python: "3.12"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements: [docs]
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv run --group docs sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,6 +17,7 @@ PYPROJECT = nox.project.load_toml("pyproject.toml")
 ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 ALL_PYTHONS += ["3.14", "pypy-3.10"]
 
+
 @nox.session(python="3.8")
 def mypy(session: nox.Session) -> None:
     """
@@ -50,6 +51,7 @@ def test(session: nox.Session) -> None:
         "tests/",
         *session.posargs,
     )
+
 
 @nox.session(venv_backend="uv", default=False, python=ALL_PYTHONS)
 def minimums(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,12 +11,11 @@ import os.path
 import nox
 
 nox.needs_version = ">=2025.2.9"
-nox.options.reuse_existing_virtualenvs = True
 nox.options.default_venv_backend = "uv|virtualenv"
 
-ALL_PYTHONS = nox.project.python_versions(nox.project.load_toml("pyproject.toml"))
+PYPROJECT = nox.project.load_toml("pyproject.toml")
+ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 ALL_PYTHONS += ["3.14", "pypy-3.10"]
-
 
 @nox.session(python="3.8")
 def mypy(session: nox.Session) -> None:
@@ -38,12 +37,35 @@ def test(session: nox.Session) -> None:
         session.virtualenv.location, f"coverage-{session.python}.xml"
     )
 
-    session.install("-e.[test]")
+    test_grp = nox.project.dependency_groups(PYPROJECT, "test")
+    session.install("-e.", *test_grp)
 
     session.run(
         "pytest",
         "--cov",
         f"--cov-report=html:{htmlcov_output}",
+        f"--cov-report=xml:{xmlcov_output}",
+        "--cov-report=term-missing",
+        "--cov-context=test",
+        "tests/",
+        *session.posargs,
+    )
+
+@nox.session(venv_backend="uv", default=False, python=ALL_PYTHONS)
+def minimums(session: nox.Session) -> None:
+    """
+    Check minimum requirements.
+    """
+    test_grp = nox.project.dependency_groups(PYPROJECT, "test")
+    session.install("-e.", "--resolution=lowest-direct", *test_grp, silent=False)
+
+    xmlcov_output = os.path.join(
+        session.virtualenv.location, f"coverage-{session.python}-min.xml"
+    )
+
+    session.run(
+        "pytest",
+        "--cov",
         f"--cov-report=xml:{xmlcov_output}",
         "--cov-report=term-missing",
         "--cov-context=test",
@@ -66,7 +88,8 @@ def docs(session: nox.Session) -> None:
 
     serve = args.builder == "html" and session.interactive
     extra_installs = ["sphinx-autobuild"] if serve else []
-    session.install("-e.[docs]", *extra_installs)
+    docs_grp = nox.project.dependency_groups(PYPROJECT, "docs")
+    session.install("-e.", *docs_grp, *extra_installs)
 
     session.chdir("docs")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ dependencies = [
     "packaging>=23.2",
 ]
 
-[project.optional-dependencies]
+[project.urls]
+changelog = "https://pep621.readthedocs.io/en/stable/changelog.html"
+homepage = "https://github.com/pypa/pyproject-metadata"
+
+[dependency-groups]
 docs = [
     "furo>=2023.9.10",
     "sphinx-autodoc-typehints>=1.10.0",
@@ -35,29 +39,25 @@ docs = [
     "myst-parser",
 ]
 test = [
-    "pytest-cov[toml]>=2",
-    "pytest>=6.2.4",
-    'tomli>=1.0.0;python_version<"3.11"',
-    'exceptiongroup;python_version<"3.11"',  # Optional
+    "pytest-cov>=4",
+    "pytest>=7.4; python_version>='3.12'",
+    "pytest>=7; python_version<'3.12'",
+    'tomli>=1.1;python_version<"3.11"',
+    'exceptiongroup>=1.0;python_version<"3.11"',  # Optional
 ]
+dev = [{include-group = "test"}]
 
-[project.urls]
-changelog = "https://pep621.readthedocs.io/en/stable/changelog.html"
-homepage = "https://github.com/pypa/pyproject-metadata"
 
 [tool.flit.sdist]
 include = ["LICENSE", "tests/**", "docs/**", ".gitignore"]
 
-[tool.uv]
-dev-dependencies = ["pyproject-metadata[test]"]
-
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
-log_cli_level = "info"
+log_cli_level = "INFO"
 testpaths = ["tests"]
 
 


### PR DESCRIPTION
Using dependency-groups.

Checking the minimum limits. Some test dependencies have been bumped a little.
