### PR TITLE
ISC rules do not conflict with the formatter any more

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ extend-select = [
   "PD",          # pandas-vet
 ]
 ignore = [
-  "ISC001",  # conflicts with formatter
   "PLR09",   # Design related (too many X)
   "PLR2004", # Magic value in comparison
 ]


### PR DESCRIPTION
https://astral.sh/blog/ruff-v0.9.0#fewer-single-line-implicitly-concatenated-strings