### PR TITLE
chore: use ruff ALL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,50 +73,29 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 show-fixes = true
 
 [tool.ruff.lint]
-extend-select = [
-  "C90",         # mccabe
-  "B",           # flake8-bugbear
-  "I",           # isort
-  "ARG",         # flake8-unused-arguments
-  "C4",          # flake8-comprehensions
-  "ICN",         # flake8-import-conventions
-  "ISC",         # flake8-implicit-str-concat
-  "EM",          # flake8-errmsg
-  "G",           # flake8-logging-format
-  "PGH",         # pygrep-hooks
-  "PIE",         # flake8-pie
-  "PL",          # pylint
-  "PT",          # flake8-pytest-style
-  "RET",         # flake8-return
-  "RUF",         # Ruff-specific
-  "SIM",         # flake8-simplify
-  "T20",         # flake8-print
-  "UP",          # pyupgrade
-  "YTT",         # flake8-2020
-  "EXE",         # flake8-executable
-  "BLE",         # flake8-blind-except
-  "DTZ",         # flake8-datetimez
-  "FA",          # flake8-future-annotations
-  "FLY",         # flynt
-  "FURB",        # refurb
-  "LOG",         # flake8-logging
-  "PERF",        # Perflint
-  "PTH",         # flake8-use-pathlib
-  "PYI",         # flake8-pyi
-  "Q",           # flake8-quotes
-  "RSE",         # flake8-raise
-  "SLOT",        # flake8-slots
-  "T10",         # flake8-debugger
-  "TC",          # flake8-type-checking
-  "TRY",         # tryceratops
-]
+select = ["ALL"]
 ignore = [
+  "S101",    # Asserts are used by mypy and pytest
   "PLR09",   # Design related (too many X)
   "PLR2004", # Magic value in comparison
+  "COM812",  # Trailing commas inform the formatter
+  "D",       # Docstring stuff (TODO)
+  "E501",    # Not worried about long lines in strings
 ]
+flake8-builtins.ignorelist = ["copyright"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["PTH123"]
+"tests/**" = [
+  "PTH123",  # Path.open not needed for simple files
+  "D",       # Tests don't need docs
+  "INP001",  # Tests don't need an __init__
+  "FBT001",  # Bools are fine in test fixutres/params
+  "SLF001",  # Tests can access private members
+]
+"docs/**" = [
+  "INP001",  # Docs don't need an __init__
+  "ERA001",  # Commented out code in conf.py
+]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -198,7 +198,10 @@ class RFC822Policy(email.policy.EmailPolicy):
     if sys.version_info < (3, 12, 4):
         # Work around Python bug https://github.com/python/cpython/issues/117313
         def _fold(
-            self, name: str, value: Any, refold_binary: bool = False
+            self,
+            name: str,
+            value: Any,  # noqa: ANN401
+            refold_binary: bool = False,  # noqa: FBT001, FBT002
         ) -> str:  # pragma: no cover
             if hasattr(value, "name"):
                 return value.fold(policy=self)  # type: ignore[no-any-return]
@@ -207,7 +210,6 @@ class RFC822Policy(email.policy.EmailPolicy):
             # this is from the library version, and it improperly breaks on chars like 0x0c, treating
             # them as 'form feed' etc.
             # we need to ensure that only CR/LF is used as end of line
-            # lines = value.splitlines()
 
             # this is a workaround which splits only on CR/LF characters
             if isinstance(value, bytes):
@@ -222,7 +224,9 @@ class RFC822Policy(email.policy.EmailPolicy):
                     or any(len(x) > maxlen for x in lines[1:])
                 )
             )
-            if refold or (refold_binary and email.policy._has_surrogates(value)):  # type: ignore[attr-defined]
+            if refold or (
+                refold_binary and email.policy._has_surrogates(value)  # type: ignore[attr-defined] # noqa: SLF001
+            ):
                 return self.header_factory(name, "".join(lines)).fold(policy=self)  # type: ignore[arg-type,no-any-return]
             return name + ": " + self.linesep.join(lines) + self.linesep  # type: ignore[arg-type]
 
@@ -278,7 +282,9 @@ class RFC822Message(email.message.EmailMessage):
         super().__init__(policy=RFC822Policy())
 
     def as_bytes(
-        self, unixfrom: bool = False, policy: email.policy.Policy | None = None
+        self,
+        unixfrom: bool = False,  # noqa: FBT001, FBT002
+        policy: email.policy.Policy | None = None,
     ) -> bytes:
         """
         This handles unicode encoding.
@@ -772,7 +778,7 @@ def _build_extra_req(
     """
     requirement = copy.copy(requirement)
     if requirement.marker:
-        if "or" in requirement.marker._markers:
+        if "or" in requirement.marker._markers:  # noqa: SLF001
             requirement.marker = packaging.markers.Marker(
                 f"({requirement.marker}) and extra == {extra!r}"
             )

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -31,7 +31,7 @@ class ConfigurationError(Exception):
     """Error in the backend metadata. Has an optional key attribute, which will be non-None
     if the error is related to a single key in the pyproject.toml file."""
 
-    def __init__(self, msg: str, *, key: str | None = None):
+    def __init__(self, msg: str, *, key: str | None = None) -> None:
         super().__init__(msg)
         self._key = key
 
@@ -48,7 +48,7 @@ if sys.version_info >= (3, 11):
     ExceptionGroup = builtins.ExceptionGroup
 else:
 
-    class ExceptionGroup(Exception):
+    class ExceptionGroup(Exception):  # noqa: N818
         """A minimal implementation of `ExceptionGroup` from Python 3.11.
 
         Users can replace this with a more complete implementation, such as from
@@ -83,10 +83,10 @@ class ErrorCollector:
         msg: str,
         *,
         key: str | None = None,
-        got: typing.Any = None,
+        got: object = None,
         got_type: type[typing.Any] | None = None,
         warn: bool = False,
-        **kwargs: typing.Any,
+        **kwargs: object,
     ) -> None:
         """Raise a configuration error, or add it to the error list."""
         msg = msg.format(key=f'"{key}"', **kwargs)


### PR DESCRIPTION
Enabling "ALL" and just ignoring a few rules.
