### PR TITLE
chore: add branch coverage, fill in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,10 @@ pydocstyle.convention = "pep257"
 docstring-code-format = true
 
 [tool.coverage]
+run.branch = true
+run.source_pkgs = ["pyproject_metadata"]
 html.show_contexts = true
+report.show_missing = true
 report.exclude_also = [
     "if typing.TYPE_CHECKING:",
 ]

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -626,14 +626,14 @@ class StandardMetadata:
             isinstance(self.license, str)
             and self.auto_metadata_version in constants.PRE_SPDX_METADATA_VERSIONS
         ):
-            msg = "Setting {key} to an SPDX license expression is supported only when emitting metadata version >= 2.4"
+            msg = "Setting {key} to an SPDX license expression is only supported when emitting metadata version >= 2.4"
             errors.config_error(msg, key="project.license")
 
         if (
             self.license_files is not None
             and self.auto_metadata_version in constants.PRE_SPDX_METADATA_VERSIONS
         ):
-            msg = "{key} is supported only when emitting metadata version >= 2.4"
+            msg = "{key} is only supported when emitting metadata version >= 2.4"
             errors.config_error(msg, key="project.license-files")
 
         for name in self.urls:
@@ -736,8 +736,8 @@ class StandardMetadata:
                     _build_extra_req(norm_extra, requirement)
                 )
         if self.readme:
-            if self.readme.content_type:
-                smart_message["Description-Content-Type"] = self.readme.content_type
+            assert self.readme.content_type  # verified earlier
+            smart_message["Description-Content-Type"] = self.readme.content_type
             smart_message.set_payload(self.readme.text)
         for import_name in self.import_names or []:
             smart_message["Import-Name"] = import_name

--- a/tests/packages/full-metadata/pyproject.toml
+++ b/tests/packages/full-metadata/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     { name = 'Example!' },
 ]
 maintainers = [
+    { name = 'Emailless' },
     { name = 'Other Example', email = 'other@example.com' },
 ]
 classifiers = [


### PR DESCRIPTION
Branch coverage. Running coverage on the package only to avoid false positives in tests (linting ensures test code runs). Some assorted fixes based on work in packaging.

Adjusting word order in a couple of exceptions for consistency.