### PR TITLE
ci: bump macOS intel to 15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           - "3.13"
           - "3.14"
         include:
-          - os: macos-13
+          - os: macos-15-intel
             python: "3.8"
           - os: macos-14
             python: "3.12"


### PR DESCRIPTION
13 is being phased out.
