### PR TITLE
ci: fix changelog filtering

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
Now `[bot]` is required.
