### PR TITLE
Add documentation project URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 
 [project.urls]
 changelog = "https://pep621.readthedocs.io/en/stable/changelog.html"
+documentation = "https://pep621.readthedocs.io/en/stable/"
 homepage = "https://github.com/pypa/pyproject-metadata"
 
 [dependency-groups]


### PR DESCRIPTION
Adds the current Read the Docs URL to the project metadata so the docs target is explicit.

Closes #88.

Checks:
- pre-commit run check-toml --files pyproject.toml
- pre-commit run validate-pyproject --files pyproject.toml
- uv build
- git diff --check