### PR TITLE
ci: secure GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
           - "*"
     cooldown:
       default-days: 7
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      pre-commit:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,22 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,5 @@
 name: checks
+
 on:
   push:
     branches:
@@ -6,18 +7,27 @@ on:
       - v*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   mypy:
+    name: Type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run check for type
         run: uv run noxfile.py -s mypy

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,4 @@
 name: checks
-
 on:
   push:
     branches:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,8 +14,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  mypy:
-    name: Type checking
+  mypy: # zizmor: ignore[anonymous-definition] required check; name must stay as the job id
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,25 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
-  # Always build & lint package.
   build-package:
     name: Build & verify
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
-  # Upload to real PyPI on GitHub Releases.
   release-pypi:
     name: Publish to pypi.org
     environment: release
@@ -29,12 +37,12 @@ jobs:
     needs: build-package
     if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write # OIDC for PyPI trusted publishing
+      attestations: write # Artifact attestation signing
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
@@ -45,4 +53,4 @@ jobs:
           subject-path: "dist/pyproject*"
 
       - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   pytest:
-    name: Test Python ${{ matrix.python }}
+    name: Test Python ${{ matrix.python }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,11 +62,13 @@ jobs:
 
       - name: Run tests
         run: uv run noxfile.py -s test-$PYTHON
+        shell: bash
         env:
           PYTHON: ${{ matrix.python }}
 
       - name: Run minimum tests
         run: uv run noxfile.py -s minimums-$PYTHON
+        shell: bash
         env:
           PYTHON: ${{ matrix.python }}
 
@@ -108,7 +110,7 @@ jobs:
       - name: Run nox
         run: uvx nox -s "downstream(project=\"$PROJECT\")"
         env:
-          PYTHON: ${{ matrix.project }}
+          PROJECT: ${{ matrix.project }}
 
   # https://github.com/marketplace/actions/alls-green#why
   required-checks-pass:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   pytest:
+    name: Test Python ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -44,16 +47,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up target Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run tests
         run: uv run noxfile.py -s test-${{ matrix.python }}
@@ -62,7 +67,7 @@ jobs:
         run: uv run noxfile.py -s minimums-${{ matrix.python }}
 
       - name: Send coverage report
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           PYTHON: ${{ matrix.python }}
         with:
@@ -84,23 +89,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up target Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run nox
         run: uvx nox -s 'downstream(project="${{ matrix.project }}")'
 
   # https://github.com/marketplace/actions/alls-green#why
-  required-checks-pass: # This job does nothing and is only used for the branch protection
+  required-checks-pass:
+    name: All checks passed
     if: always()
 
     needs:
@@ -111,6 +117,6 @@ jobs:
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,10 +61,14 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run tests
-        run: uv run noxfile.py -s test-${{ matrix.python }}
+        run: uv run noxfile.py -s test-$PYTHON
+        env:
+          PYTHON: ${{ matrix.python }}
 
       - name: Run minimum tests
-        run: uv run noxfile.py -s minimums-${{ matrix.python }}
+        run: uv run noxfile.py -s minimums-$PYTHON
+        env:
+          PYTHON: ${{ matrix.python }}
 
       - name: Send coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -102,7 +106,9 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run nox
-        run: uvx nox -s 'downstream(project="${{ matrix.project }}")'
+        run: uvx nox -s "downstream(project=\"$PROJECT\")"
+        env:
+          PYTHON: ${{ matrix.project }}
 
   # https://github.com/marketplace/actions/alls-green#why
   required-checks-pass:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,7 @@ jobs:
           PROJECT: ${{ matrix.project }}
 
   # https://github.com/marketplace/actions/alls-green#why
-  required-checks-pass:
-    name: All checks passed
+  required-checks-pass: # zizmor: ignore[anonymous-definition] required check; name must stay as the job id
     if: always()
 
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
       - pytest
       - downstream
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,6 +1,0 @@
-rules:
-  template-injection:
-    ignore:
-      - tests.yml:63
-      - tests.yml:66
-      - tests.yml:104

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,6 @@
+rules:
+  template-injection:
+    ignore:
+      - tests.yml:63
+      - tests.yml:66
+      - tests.yml:104

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
     rev: 122913fcf3aa27fa6867c902c3e803b7bff22d28 # frozen: v1.25.0
     hooks:
       - id: zizmor
-        files: "^\\.github"
+        files: "^\\.github/workflows"
         args: [--persona=pedantic]
 
   - repo: https://github.com/scientific-python/cookie

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: ^tests/packages/broken_license/LICENSE$
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -21,34 +21,34 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.15"
+    rev: "0671d8ab202c4ac093b78433ae5baf74f3fc7246" # frozen: v0.15.15
     hooks:
       - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
+    rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316 # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.20.0
+    rev: fda77690955e9b63c6687d8806bafd56a526e45f # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==25.*]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.3"
+    rev: "515f543f5718ebfd6ce22e16708bb32c68ff96e1" # frozen: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/henryiii/check-sdist
-    rev: "v1.4.0"
+    rev: "8d786ae74939ac1d9b12681bc43f72a0980283dd" # frozen: v1.4.0
     hooks:
       - id: check-sdist
         args: [--inject-junk]
@@ -56,23 +56,23 @@ repos:
           - flit-core
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a # frozen: v2.4.2
     hooks:
       - id: codespell
         exclude: ^(LICENSE$|src/scikit_build_core/resources/find_python|tests/test_skbuild_settings.py$)
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.05.28
+    rev: a4ec1952e236bbc3b6ec29909724a33ff9d83327 # frozen: 2026.05.28
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: f805888065fdb6162e1f800e50bb9460cbd223d6 # frozen: 0.37.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
@@ -80,7 +80,14 @@ repos:
       - id: check-metaschema
         files: \.schema\.json
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 122913fcf3aa27fa6867c902c3e803b7bff22d28 # frozen: v1.25.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]
+
   - repo: https://github.com/scientific-python/cookie
-    rev: 2026.04.04
+    rev: 04d0e44c1d3b036e9714aca375d965504ba5ea4a # frozen: 2026.04.04
     hooks:
       - id: sp-repo-review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,5 +117,8 @@ report.exclude_also = [
     "if typing.TYPE_CHECKING:",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.repo-review]
 ignore = ["PC140"]


### PR DESCRIPTION
Used [my secure-ci skill](https://github.com/henryiii/skills/blob/main/secure-ci/SKILL.md), and tweaked a bit.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Secure the repository's GitHub Actions workflows following zizmor pedantic audit and best practices.

## Changes

- **Pin all GHA actions to SHA hashes** with version comments (14 actions across 3 workflows + codecov)
- **Add zizmor pre-commit hook** and `.github/zizmor.yaml` config for ongoing auditing
- **Fix `checks.yml`**: added `permissions: {}`, concurrency group, `persist-credentials: false`, job name
- **Fix `release.yml`**: added `permissions: {}`, concurrency group, `persist-credentials: false`, job-level permissions with explanatory comments, `contents: read` for build job
- **Fix `tests.yml`**: added `permissions: {}`, `persist-credentials: false`, job names for pytest and required-checks-pass
- **Update `.github/dependabot.yml`**: switched to monthly schedule, added 7-day cooldown, ~~added pre-commit ecosystem~~, updated group name from `actions` to `github-actions`
- **Freeze all pre-commit hook revs** to SHA pins via `prek auto-update --freeze --cooldown-days 7`
- **Add `tool.uv.exclude-newer = "7 days"`** cooldown to `pyproject.toml`

Assisted-by: OpenCode:glm-5