### PR TITLE
Fix UTF-8 author and maintainer names

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -37,12 +37,12 @@ import copy
 import dataclasses
 import email.message
 import email.policy
-import email.utils
 import itertools
 import keyword
 import os
 import os.path
 import pathlib
+import re
 import sys
 import typing
 import warnings
@@ -747,14 +747,23 @@ def _name_list(people: list[tuple[str, str | None]]) -> str | None:
     return ", ".join(name for name, email_ in people if not email_) or None
 
 
+_DISPLAY_NAME_NEEDS_QUOTING = re.compile(r'[][\\()<>@,:;".]')
+_QUOTED_STRING_ESCAPE = re.compile(r'([\\"])')
+
+
+def _format_address(name: str, addr: str) -> str:
+    if _DISPLAY_NAME_NEEDS_QUOTING.search(name):
+        quoted = _QUOTED_STRING_ESCAPE.sub(r"\\\1", name)
+        return f'"{quoted}" <{addr}>'
+    return f"{name} <{addr}>"
+
+
 def _email_list(people: list[tuple[str, str | None]]) -> str | None:
     """
     Build a comma-separated list of emails.
     """
     return (
-        ", ".join(
-            email.utils.formataddr((name, _email)) for name, _email in people if _email
-        )
+        ", ".join(_format_address(name, _email) for name, _email in people if _email)
         or None
     )
 

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -248,6 +248,27 @@ def test_convert_author_email() -> None:
     ]
 
 
+def test_convert_author_email_non_ascii() -> None:
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        {
+            "project": {
+                "name": "example",
+                "version": "0.1.0",
+                "authors": [
+                    {"name": "Antonín Dvořák", "email": "dvorak@example.com"},
+                ],
+                "maintainers": [
+                    {"name": "Björk", "email": "bjork@example.com"},
+                ],
+            },
+        }
+    )
+    message = str(metadata.as_rfc822())
+    assert "Author-Email: Antonín Dvořák <dvorak@example.com>" in message
+    assert "Maintainer-Email: Björk <bjork@example.com>" in message
+    assert "=?utf-8?" not in message
+
+
 def test_long_version() -> None:
     metadata = pyproject_metadata.StandardMetadata.from_pyproject(
         {

--- a/tests/test_rfc822.py
+++ b/tests/test_rfc822.py
@@ -255,7 +255,7 @@ def test_convert_author_email_non_ascii() -> None:
                 "name": "example",
                 "version": "0.1.0",
                 "authors": [
-                    {"name": "Antonín Dvořák", "email": "dvorak@example.com"},
+                    {"name": 'Antonín "Leopold" Dvořák', "email": "dvorak@example.com"},
                 ],
                 "maintainers": [
                     {"name": "Björk", "email": "bjork@example.com"},
@@ -264,7 +264,7 @@ def test_convert_author_email_non_ascii() -> None:
         }
     )
     message = str(metadata.as_rfc822())
-    assert "Author-Email: Antonín Dvořák <dvorak@example.com>" in message
+    assert r'Author-Email: "Antonín \"Leopold\" Dvořák" <dvorak@example.com>' in message
     assert "Maintainer-Email: Björk <bjork@example.com>" in message
     assert "=?utf-8?" not in message
 


### PR DESCRIPTION
If the maintainer or author name has non-ASCII characters, the output is shown on PyPI encoded.

For example, https://pypi.org/project/turbohtml/ shows "=?utf-8?b?QmVybsOhdCBHw6Fib3I=?=" instead of "Bernát Gábor".

Here's a repro:

```python
import tomllib
from pyproject_metadata import StandardMetadata

PYPROJECT = """
[project]
name = "demo"
version = "0.0.0"
maintainers = [
  { name = "Björk", email = "name@example.com" },
]
"""


parsed_pyproject = tomllib.loads(PYPROJECT)
metadata = StandardMetadata.from_pyproject(parsed_pyproject)
pkg_info = metadata.as_rfc822()

print("--- generated METADATA ---")
print(pkg_info)
print("--- /generated METADATA ---")

expected = "Maintainer-email: Björk <name@example.com>"
for line in str(pkg_info).splitlines():
    if line.lower().startswith("maintainer-email:"):
        assert line == expected, (
            f"\n"
            f"  expected: {expected!r}\n"
            f"  got:      {line!r}"
        )
```

Gives:


```pytb
--- generated METADATA ---
Metadata-Version: 2.1
Name: demo
Version: 0.0.0
Maintainer-Email: =?utf-8?b?QmrDtnJr?= <name@example.com>


--- /generated METADATA ---
Traceback (most recent call last):
  File "/private/tmp/pyproject-metadata/../repros/pyproject-metadata-repro/repro.py", line 25, in <module>
    assert line == expected, (
           ^^^^^^^^^^^^^^^^
AssertionError:
  expected: 'Maintainer-email: Björk <name@example.com>'
  got:      'Maintainer-Email: =?utf-8?b?QmrDtnJr?= <name@example.com>'
```

