### PR TITLE
fix: correct Import-Namespace field name in PROJECT_TO_METADATA

### DIFF
--- a/pyproject_metadata/constants.py
+++ b/pyproject_metadata/constants.py
@@ -48,7 +48,7 @@ PROJECT_TO_METADATA = {
     "urls": frozenset(["Project-URL"]),
     "version": frozenset(["Version"]),
     "import-names": frozenset(["Import-Name"]),
-    "import-namespaces": frozenset(["Import-Namespaces"]),
+    "import-namespaces": frozenset(["Import-Namespace"]),
 }
 
 KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1674,6 +1674,17 @@ def test_as_rfc822_mapped_dynamic() -> None:
     )
 
 
+def test_project_to_metadata_fields_are_known() -> None:
+    """All metadata field names in PROJECT_TO_METADATA must be known metadata fields."""
+    unknown = {
+        field
+        for fields in pyproject_metadata.constants.PROJECT_TO_METADATA.values()
+        for field in fields
+        if field.lower() not in pyproject_metadata.constants.KNOWN_METADATA_FIELDS
+    }
+    assert not unknown, f"Unknown metadata fields in PROJECT_TO_METADATA: {unknown}"
+
+
 def test_as_rfc822_missing_version() -> None:
     metadata = pyproject_metadata.StandardMetadata(name="something")
     with pytest.raises(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`PROJECT_TO_METADATA["import-namespaces"]` in `pyproject_metadata/constants.py` (line 51) mapped to `frozenset(["Import-Namespaces"])` — the plural form — but the actual core-metadata field is `Import-Namespace` (singular). This is consistent with:
- `_write_metadata` in `__init__.py` which emits `smart_message["Import-Namespace"] = ...`
- `KNOWN_METADATA_FIELDS` which contains `"import-namespace"` (singular)
- `KNOWN_MULTIUSE` which contains `"import-namespace"` (singular)

As a result, `pyproject_metadata.field_to_metadata("import-namespaces")` returned `frozenset({"Import-Namespaces"})`, and using that result (e.g. passing it to `dynamic_metadata` as shown in `test_as_rfc822_mapped_dynamic`) would fail with an "unknown metadata field" error.

## Fix

- Change `frozenset(["Import-Namespaces"])` → `frozenset(["Import-Namespace"])` in `constants.py`
- Add a regression test `test_project_to_metadata_fields_are_known` that asserts every metadata field name in `PROJECT_TO_METADATA.values()` is present (lowercased) in `KNOWN_METADATA_FIELDS`, preventing this class of typo in future

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.