### PR TITLE
fix: handle braces in user data within error messages

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -730,11 +730,11 @@ class StandardMetadata:
         if self.auto_metadata_version != "2.1":
             for field in self.dynamic_metadata:
                 if field.lower() in {"name", "version", "dynamic"}:
-                    msg = f"Metadata field {field!r} cannot be declared dynamic"
-                    errors.config_error(msg)
+                    msg = "Metadata field {field!r} cannot be declared dynamic"
+                    errors.config_error(msg, field=field)
                 if field.lower() not in constants.KNOWN_METADATA_FIELDS:
-                    msg = f"Unknown metadata field {field!r} cannot be declared dynamic"
-                    errors.config_error(msg)
+                    msg = "Unknown metadata field {field!r} cannot be declared dynamic"
+                    errors.config_error(msg, field=field)
                 smart_message["Dynamic"] = field
 
         errors.finalize("Failed to write metadata")

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -133,8 +133,10 @@ def get_license(
     if filename:
         file = project_dir.joinpath(filename)
         if not file.is_file():
-            msg = f"License file not found ({filename!r})"
-            error_collector.config_error(msg, key="project.license.file")
+            msg = "License file not found ({filename!r})"
+            error_collector.config_error(
+                msg, key="project.license.file", filename=filename
+            )
             return None
         text = file.read_text(encoding="utf-8")
 

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1662,6 +1662,35 @@ def test_as_rfc822_invalid_dynamic() -> None:
         metadata.as_rfc822()
 
 
+def test_license_file_not_found_with_braces() -> None:
+    with pytest.raises(
+        pyproject_metadata.ConfigurationError,
+        match=re.escape("License file not found ('LICENSE{oops}')"),
+    ):
+        pyproject_metadata.StandardMetadata.from_pyproject(
+            {
+                "project": {
+                    "name": "example",
+                    "version": "1.0",
+                    "license": {"file": "LICENSE{oops}"},
+                }
+            }
+        )
+
+
+def test_as_rfc822_invalid_dynamic_with_braces() -> None:
+    metadata = pyproject_metadata.StandardMetadata(
+        name="something",
+        version=packaging.version.Version("1.0.0"),
+        dynamic_metadata=["{key}"],
+    )
+    with pytest.raises(
+        pyproject_metadata.ConfigurationError,
+        match=re.escape("Unknown metadata field '{key}' cannot be declared dynamic"),
+    ):
+        metadata.as_rfc822()
+
+
 def test_as_rfc822_mapped_dynamic() -> None:
     metadata = pyproject_metadata.StandardMetadata(
         name="something",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`ErrorCollector.config_error` (in `pyproject_metadata/errors.py`) runs `msg.format(key=..., **kwargs)` on its message. A few call sites passed an **already-formatted** f-string that embedded user-controlled data, so braces in that data crashed `.format()` instead of producing the intended error.

Repro:

```python
import pyproject_metadata
pyproject_metadata.StandardMetadata.from_pyproject(
    {"project": {"name": "example", "version": "1.0", "license": {"file": "LICENSE{oops}"}}}
)
# KeyError: 'oops'  -- instead of "License file not found"
```

The same flaw affected `dynamic_metadata` entries containing braces when writing metadata.

## Fix

Replace the pre-formatted f-strings with placeholder templates and pass the user data as keyword arguments, matching the pattern already used by `get_readme`:

- `pyproject.py` `get_license`: `"License file not found ({filename!r})"` + `filename=filename`
- `__init__.py` `_write_metadata`: the two "cannot be declared dynamic" messages now use a `{field!r}` placeholder + `field=field`

Error message output is byte-identical for non-brace inputs (existing exact-match tests still pass). Audited all other `config_error` call sites; the rest already use placeholder templates, and the one remaining f-string (`header_store_parse`) raises `ConfigurationError` directly without `.format()`, so it is unaffected.

## Tests

Added two regression tests in `tests/test_standard_metadata.py`: a license file path with braces produces the proper "License file not found" error, and a `dynamic_metadata` entry of `"{key}"` produces the proper "Unknown metadata field" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.