### PR TITLE
fix: error on unset dynamic version instead of emitting 0.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+Fixes:
+
+- Error on an unset dynamic version instead of silently writing
+  `Version: 0.0.0`. If `"version"` is declared in `project.dynamic` but never
+  assigned by the build backend, writing the metadata now raises a
+  `ConfigurationError` (`Field "project.version" missing`), restoring the 0.8.x
+  behavior that regressed in the 0.9 rewrite.
+
 ## 0.11.0 (2-9-2026)
 
 This release refactors a lot of the internals to break up conversion and

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -447,7 +447,14 @@ class StandardMetadata:
                         if version_string
                         else None
                     )
-        elif "version" not in dynamic:
+        elif "version" in dynamic:
+            # A dynamic version that has not been assigned yet is None; the
+            # build backend is expected to set ``metadata.version`` before
+            # writing the metadata. The 0.0.0 placeholder is only kept for the
+            # error-collection paths (version present but invalid) so parsing
+            # can continue under ``all_errors=True``.
+            version = None
+        else:
             msg = (
                 "Field {key} missing and 'version' not specified in \"project.dynamic\""
             )

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1738,6 +1738,34 @@ def test_version_dynamic() -> None:
     metadata.version = packaging.version.Version("1.2.3")
 
 
+def test_version_dynamic_unset() -> None:
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        {
+            "project": {
+                "name": "example",
+                "dynamic": [
+                    "version",
+                ],
+            },
+        }
+    )
+    assert metadata.version is None
+    with pytest.raises(
+        pyproject_metadata.errors.ConfigurationError,
+        match=re.escape('Field "project.version" missing'),
+    ):
+        metadata.as_rfc822()
+    with pytest.raises(
+        pyproject_metadata.errors.ConfigurationError,
+        match=re.escape('Field "project.version" missing'),
+    ):
+        metadata.as_json()
+
+    # Assigning a dynamic version before writing the metadata works as usual.
+    metadata.version = packaging.version.Version("1.2.3")
+    assert "Version: 1.2.3" in metadata.as_rfc822().as_string()
+
+
 def test_modify_dynamic() -> None:
     metadata = pyproject_metadata.StandardMetadata.from_pyproject(
         {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## The bug

When `version` is declared in `project.dynamic` and a build backend never assigns `metadata.version`, the written metadata silently contained `Version: 0.0.0` instead of erroring.

Repro:

```python
import pyproject_metadata
m = pyproject_metadata.StandardMetadata.from_pyproject(
    {'project': {'name': 'example', 'dynamic': ['version']}}
)
print(m.version)                  # 0.0.0
print(m.as_rfc822().as_string())  # contains "Version: 0.0.0" — no error
```

### Cause

In `from_pyproject`, `version` was initialized to the placeholder `packaging.version.Version("0.0.0")`. When `version` was absent but dynamic, it stayed at the placeholder, so the guard in `_write_metadata` (`if not self.version:` → `Field "project.version" missing`) could never fire, because the placeholder is truthy.

This is a **regression from 0.8.x**: there, `version` was `None` in this case and writing metadata raised. It was silently introduced in the 0.9 rewrite.

## The fix

When `version` is absent from `[project]` and `"version"` is in `dynamic`, set `version = None` instead of leaving the `0.0.0` placeholder. The placeholder remains **only** for the error-collection paths (field present but invalid), so parsing can still continue under `all_errors=True` and the real error is reported by table validation.

Result:

- An unassigned dynamic version now raises `ConfigurationError 'Field "project.version" missing'` on `as_rfc822()` / `as_json()`.
- A backend that assigns `metadata.version` first (the normal flow) is unaffected.

### Behavior change note

This is a behavior change for build backends that declare `version` as dynamic but forget to assign it before writing metadata: they now get a clear error instead of a silent `Version: 0.0.0`. This restores the pre-0.9 (0.8.x) behavior.

## Tests

Added `test_version_dynamic_unset`: a never-assigned dynamic version makes `as_rfc822()`/`as_json()` raise `ConfigurationError` matching `Field "project.version" missing`, and assigning a version first still works.

- `prek -a --quiet`: passing
- `uv run noxfile.py -s mypy`: `Success: no issues found in 17 source files`
- `uv run pytest`: 253 passed, 83 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.