### PR TITLE
style: consistent dataclass decorator and sorted constant entries

### DIFF
--- a/pyproject_metadata/constants.py
+++ b/pyproject_metadata/constants.py
@@ -36,6 +36,8 @@ PROJECT_TO_METADATA = {
     "dynamic": frozenset(),
     "entry-points": frozenset(),
     "gui-scripts": frozenset(),
+    "import-names": frozenset(["Import-Name"]),
+    "import-namespaces": frozenset(["Import-Namespace"]),
     "keywords": frozenset(["Keywords"]),
     "license": frozenset(["License", "License-Expression"]),
     "license-files": frozenset(["License-File"]),
@@ -47,8 +49,6 @@ PROJECT_TO_METADATA = {
     "scripts": frozenset(),
     "urls": frozenset(["Project-URL"]),
     "version": frozenset(["Version"]),
-    "import-names": frozenset(["Import-Name"]),
-    "import-namespaces": frozenset(["Import-Namespace"]),
 }
 
 KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}
@@ -64,6 +64,8 @@ KNOWN_METADATA_FIELDS = {
     "download-url",  # Not specified via pyproject standards, deprecated by PEP 753
     "dynamic",  # Can't be in dynamic
     "home-page",  # Not specified via pyproject standards, deprecated by PEP 753
+    "import-name",
+    "import-namespace",
     "keywords",
     "license",
     "license-expression",
@@ -86,8 +88,6 @@ KNOWN_METADATA_FIELDS = {
     "summary",
     "supported-platform",  # Not specified via pyproject standards
     "version",  # Can't be in dynamic
-    "import-name",
-    "import-namespace",
 }
 
 KNOWN_MULTIUSE = {

--- a/pyproject_metadata/errors.py
+++ b/pyproject_metadata/errors.py
@@ -130,7 +130,7 @@ class SimpleErrorCollector:
             raise error
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class ErrorCollector(SimpleErrorCollector):
     """
     Collect errors and raise them as a group at the end (if collect_errors is True),


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- Drop empty parens from `@dataclasses.dataclass()` in `errors.py` — every other dataclass decorator in the package is bare
- Move `import-name`/`import-namespace` into alphabetical order in `KNOWN_METADATA_FIELDS` in `constants.py`
- Move `import-names`/`import-namespaces` into alphabetical order in `PROJECT_TO_METADATA` in `constants.py`

No behavior changes — these are sets/dicts so reordering has no runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.