### PR TITLE
perf: cache get_type_hints and precompile dispatch patterns

### DIFF
--- a/pyproject_metadata/_dispatch.py
+++ b/pyproject_metadata/_dispatch.py
@@ -41,7 +41,7 @@ T = typing.TypeVar("T")
 class KeyDispatcher(Generic[P, R]):
     def __init__(self, func: Callable[Concatenate[str, P], R]) -> None:
         self.default: Callable[Concatenate[str, P], R] = func
-        self.registry: dict[str, Callable[Concatenate[str, P], R]] = {}
+        self.registry: dict[re.Pattern[str], Callable[Concatenate[str, P], R]] = {}
         functools.update_wrapper(self, func)
 
     def register(
@@ -52,16 +52,17 @@ class KeyDispatcher(Generic[P, R]):
         def decorator(
             func: Callable[Concatenate[str, P], R],
         ) -> Callable[Concatenate[str, P], R]:
-            self.registry[value] = func
+            self.registry[re.compile(value, re.ASCII)] = func
             return func
 
         return decorator
 
     def dispatch(self, value: str) -> Callable[Concatenate[str, P], R]:
         """Return the registered implementation or the default."""
-        results = [key for key in self.registry if re.fullmatch(key, value, re.ASCII)]
-        result = results[0] if results else ""
-        return self.registry.get(result, self.default)
+        for pattern, func in self.registry.items():
+            if pattern.fullmatch(value):
+                return func
+        return self.default
 
     def __call__(self, value: str, *args: P.args, **kwargs: P.kwargs) -> R:
         impl = self.dispatch(value)

--- a/pyproject_metadata/project_table.py
+++ b/pyproject_metadata/project_table.py
@@ -10,6 +10,7 @@ Documentation notice: the fields with hyphens are not shown due to a sphinx-auto
 
 from __future__ import annotations
 
+import functools
 import re
 import sys
 import typing
@@ -292,6 +293,12 @@ def _(prefix: str, data: object, error_collector: SimpleErrorCollector) -> None:
         error_collector.error(ConfigurationError(msg, key=prefix))
 
 
+@functools.lru_cache(maxsize=None)
+def _get_type_hints(cls: type[object]) -> dict[str, Any]:
+    """Cache ``typing.get_type_hints`` results per class."""
+    return typing.get_type_hints(cls)
+
+
 def _cast_typed_dict(
     cls: type[Any], data: object, prefix: str, error_collector: SimpleErrorCollector
 ) -> None:
@@ -302,7 +309,7 @@ def _cast_typed_dict(
         msg = f'Field "{prefix}" has an invalid type, expecting {get_name(cls)} (got {get_name(type(data))})'
         raise ConfigurationTypeError(msg, key=prefix)
 
-    hints = typing.get_type_hints(cls)
+    hints = _get_type_hints(cls)  # type: ignore[arg-type]
     for key, typ in hints.items():
         if key in data:
             with error_collector.collect(ConfigurationError):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two no-behavior-change micro-optimizations for the validation path, relevant to build backends that parse many `pyproject.toml` files:

- **`project_table.py` — cache `typing.get_type_hints`**: `_cast_typed_dict` previously called `typing.get_type_hints(cls)` on every invocation — once per `ContactTable` entry (each author/maintainer) and once per dependency-groups include. `get_type_hints` re-evaluates string annotations each call. A module-level `@functools.lru_cache(maxsize=None)` wrapper `_get_type_hints` memoizes the result per TypedDict class so the cost is paid only once.

- **`_dispatch.py` — precompile `KeyDispatcher` regex patterns**: `dispatch()` previously called `re.fullmatch(key, value, re.ASCII)` for every registered pattern on every visited node. Patterns are now compiled once at `register()` time via `re.compile(value, re.ASCII)` and stored as `re.Pattern[str]` keys. `dispatch()` uses `pattern.fullmatch(value)`, eliminating repeated compilation overhead and the intermediate list allocation.

## Test plan

- [x] `prek -a --quiet` — lint passes
- [x] `uv run noxfile.py -s mypy` — mypy strict passes (17 source files, no issues)
- [x] `uv run pytest` — 252 passed, 83 skipped (skips are pre-existing exceptiongroup unavailability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.