### PR TITLE
fix: tighten license-files glob checks and private-tag parsing

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -249,8 +249,8 @@ def _validate_import_names(
     for fullname in names:
         if not isinstance(fullname, str):
             continue
-        name, simicolon, private = fullname.partition(";")
-        if simicolon and private.lstrip() != "private":
+        name, semicolon, private = fullname.partition(";")
+        if semicolon and private.strip() != "private":
             msg = "{key} contains an ending tag other than '; private', got {value!r}"
             errors.config_error(msg, key=key, value=fullname)
         name = name.rstrip()

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -12,13 +12,13 @@ record errors.
 from __future__ import annotations
 
 import dataclasses
+import pathlib
 import typing
 from typing import Any
 
 import packaging.requirements
 
 if typing.TYPE_CHECKING:
-    import pathlib
     from collections.abc import Generator, Iterable
 
     from packaging.requirements import Requirement
@@ -305,14 +305,22 @@ def _get_files_from_globs(
 ) -> Generator[pathlib.Path, None, None]:
     """Given a list of globs, get files that match."""
     for glob in globs:
-        if glob.startswith(("..", "/")):
+        # Reject any glob that escapes the project directory: absolute paths
+        # (POSIX or Windows) or any pattern containing a ".." path segment.
+        pure_path = pathlib.PurePosixPath(glob)
+        if (
+            pure_path.is_absolute()
+            or pathlib.PureWindowsPath(glob).is_absolute()
+            or ".." in pure_path.parts
+            or ".." in pathlib.PureWindowsPath(glob).parts
+        ):
             msg = "{glob!r} is an invalid {key} glob: the pattern must match files within the project directory"
             error_collector.config_error(msg, key="project.license-files", glob=glob)
-            break
+            continue
         files = [f for f in project_dir.glob(glob) if f.is_file()]
         if not files:
             msg = "Every pattern in {key} must match at least one file: {glob!r} did not match any"
             error_collector.config_error(msg, key="project.license-files", glob=glob)
-            break
+            continue
         for f in files:
             yield f.relative_to(project_dir)

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -775,6 +775,26 @@ def all_errors(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) 
                 [project]
                 name = "test"
                 version = "0.1.0"
+                license-files = ['foo/../../LICENSE']
+            """,
+            "'foo/../../LICENSE' is an invalid \"project.license-files\" glob: the pattern must match files within the project directory",
+            id="Interior dotdot license-files glob",
+        ),
+        pytest.param(
+            r"""
+                [project]
+                name = "test"
+                version = "0.1.0"
+                license-files = ['C:\LICENSE']
+            """,
+            "'C:\\\\LICENSE' is an invalid \"project.license-files\" glob: the pattern must match files within the project directory",
+            id="Windows absolute license-files glob",
+        ),
+        pytest.param(
+            """
+                [project]
+                name = "test"
+                version = "0.1.0"
                 license = 'MIT'
                 classifiers = ['License :: OSI Approved :: MIT License']
             """,
@@ -1018,6 +1038,20 @@ def test_load(
                 "\"project.import-namespaces\" is missing 'other.one', but submodules are present elsewhere",
             ],
             id="Multiple errors related to names/namespaces",
+        ),
+        pytest.param(
+            """
+                [project]
+                name = 'test'
+                version = "0.1.0"
+                license-files = ['../LICENSE', '/LICENSE', 'foo/../../LICENSE']
+            """,
+            [
+                "'../LICENSE' is an invalid \"project.license-files\" glob: the pattern must match files within the project directory",
+                "'/LICENSE' is an invalid \"project.license-files\" glob: the pattern must match files within the project directory",
+                "'foo/../../LICENSE' is an invalid \"project.license-files\" glob: the pattern must match files within the project directory",
+            ],
+            id="Multiple bad license-files globs all reported",
         ),
     ],
 )
@@ -1388,6 +1422,19 @@ def test_rfc822_empty_import_name() -> None:
         ("Version", "0.1.0"),
         ("Import-Name", ""),
     ]
+
+
+def test_import_names_private_trailing_whitespace() -> None:
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        {
+            "project": {
+                "name": "test",
+                "version": "0.1.0",
+                "import-names": ["name; private "],
+            }
+        }
+    )
+    assert metadata.import_names == ["name; private "]
 
 
 def test_rfc822_full_import_name() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes several minor edge cases found in review.

### `license-files` glob validation (`_get_files_from_globs`)
- **Interior `..` / Windows absolute paths:** the old check `glob.startswith(("..", "/"))` missed patterns that escape the project directory via interior `..` segments (e.g. `foo/../../x`) and Windows-style absolute paths (e.g. `C:\LICENSE`). The check now rejects any glob that is absolute (POSIX **or** Windows) or contains a `..` path segment, while staying correct on POSIX.
- **`break` → `continue`:** a bad glob previously aborted validation, so remaining globs went unchecked even with `all_errors=True`. It now uses `continue`, so all bad globs are reported when collecting errors. Single-error mode still raises on the first one.

### Private import-name tags (`_validate_import_names`)
- `private.lstrip() != "private"` accepted `";   private"` but rejected trailing whitespace like `"; private "`. Now uses `.strip()` so both are accepted.
- Fixed the variable-name typo `simicolon` → `semicolon`.

### Tests
Added to `tests/test_standard_metadata.py`:
- interior `..` glob and Windows absolute glob are rejected (single-error);
- multiple bad globs are all reported with `all_errors=True`;
- `"name; private "` (trailing whitespace) is accepted as a private tag.

No existing tests needed updating: the only multi-glob test added is new, and existing glob tests use a single bad glob, so the `break`→`continue` change does not alter their collected-error counts.

Verified: `prek -a --quiet` (lint), `uv run noxfile.py -s mypy` (Python 3.8), and the full `pytest` suite (345 passed with `exceptiongroup` installed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.