### PR TITLE
fix: don't crash on non-table [project] with all_errors=True

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -64,7 +64,7 @@ if typing.TYPE_CHECKING:
     else:
         from typing import Self
 
-    from .project_table import Dynamic
+    from .project_table import Dynamic, ProjectTable
 
 import contextlib
 
@@ -413,6 +413,15 @@ class StandardMetadata:
 
         assert "project" in data
         project = data["project"]
+        if not isinstance(project, dict):
+            # In non-collecting mode, to_project_table already raised; this path
+            # is only reachable with all_errors=True, where the type error was
+            # collected and finalize is guaranteed to raise.
+            error_collector.finalize("Failed to parse pyproject.toml")
+            msg = "Unreachable code"  # pragma: no cover
+            raise AssertionError(msg)  # noqa: TRY004  # pragma: no cover
+        project = typing.cast("ProjectTable", project)
+
         project_dir = pathlib.Path(project_dir)
 
         if not allow_extra_keys:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1051,6 +1051,23 @@ def test_load_multierror(
         assert "Failed to parse pyproject.toml" in repr(execinfo.value)
 
 
+def test_load_non_table_project(all_errors: bool) -> None:
+    error = 'Field "project" has an invalid type, expecting ProjectTable (got list)'
+    data = {"project": ["oops"]}
+    if not all_errors:
+        with pytest.raises(
+            pyproject_metadata.ConfigurationError, match=re.escape(error)
+        ):
+            pyproject_metadata.StandardMetadata.from_pyproject(data)
+    else:
+        with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
+            pyproject_metadata.StandardMetadata.from_pyproject(data, all_errors=True)
+        exceptions = execinfo.value.exceptions
+        args = [e.args[0] for e in exceptions]
+        assert args == [error]
+        assert "Failed to parse pyproject.toml" in repr(execinfo.value)
+
+
 @pytest.mark.parametrize(
     ("data", "error", "metadata_version"),
     [


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

`StandardMetadata.from_pyproject` crashed with an `AttributeError` (instead of raising a `ConfigurationError` / `ExceptionGroup`) when `[project]` is not a table and `all_errors=True`. It also emitted a nonsense `ExtraKeyWarning` first.

```python
import pyproject_metadata
pyproject_metadata.StandardMetadata.from_pyproject({"project": ["oops"]}, all_errors=True)
# Extra keys present in "project": 'oops'   <- nonsense warning
# AttributeError: 'list' object has no attribute 'get'
```

In collecting mode (`all_errors=True`), `to_project_table` collects the type error rather than raising it. The code then assumed `data["project"]` was a dict: `extras_project(data)` iterated the list items as keys (the bogus warning), and `project.get("dynamic", [])` raised `AttributeError`.

## Fix

After the `to_project_table` validation, if `data["project"]` is not a mapping, bail out by calling `error_collector.finalize(...)`, so the already-collected `ConfigurationTypeError` is raised as an `ExceptionGroup`. This mirrors the existing missing-`[project]` handling at the top of `from_pyproject`. In non-collecting mode `to_project_table` already raises, so the `finalize` here is guaranteed to raise (hence the unreachable `raise AssertionError` with `# pragma: no cover`).

Now both modes behave correctly:
- `all_errors=False` -> `ConfigurationError` (`ConfigurationTypeError`)
- `all_errors=True` -> `ExceptionGroup` containing the `ConfigurationTypeError`, with no spurious warning.

## Tests

Added `test_load_non_table_project` covering both `all_errors=True` and `all_errors=False` (and the `exceptiongroup` backport variant via the existing fixture).

Lint (`prek -a`), mypy (Python 3.8), and the full pytest suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #307.