### PR TITLE
ci: bump scikit-build-core downstream pin to latest main

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def docs(session: nox.Session) -> None:
 PROJECTS = {
     "sphinx-theme-builder": "https://github.com/pradyunsg/sphinx-theme-builder/archive/refs/tags/0.3.2.tar.gz",
     "meson-python": "https://github.com/mesonbuild/meson-python/archive/refs/tags/0.19.0.tar.gz",
-    "scikit-build-core": "https://github.com/scikit-build/scikit-build-core/archive/8621243325da790d8d11d8443507ffab121f9650.tar.gz",
+    "scikit-build-core": "https://github.com/scikit-build/scikit-build-core/archive/70fc6207fe58410b287be0c971ff469359dae289.tar.gz",
     "pdm-backend": "https://github.com/pdm-project/pdm-backend/archive/refs/tags/2.4.6.tar.gz",
 }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `Downstream scikit-build-core` job has been failing on unrelated PRs because the pinned commit (`8621243`) pulls the freshly released **pytest 9.1.0**, whose params-fixture override regression breaks scikit-build-core's test collection (3 errors before any pyproject-metadata code runs).

This bumps the pin in `noxfile.py` to scikit-build-core's current `main` HEAD, [`70fc620`](https://github.com/scikit-build/scikit-build-core/commit/70fc6207fe58410b287be0c971ff469359dae289), which is the commit [`ci: exclude pytest 9.1.0` (scikit-build/scikit-build-core#1329)](https://github.com/scikit-build/scikit-build-core/pull/1329) — so the downstream job stops dragging in the broken pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)