### PR TITLE
ci: bump pinned scikit-build-core

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def docs(session: nox.Session) -> None:
 PROJECTS = {
     "sphinx-theme-builder": "https://github.com/pradyunsg/sphinx-theme-builder/archive/refs/tags/0.3.2.tar.gz",
     "meson-python": "https://github.com/mesonbuild/meson-python/archive/refs/tags/0.19.0.tar.gz",
-    "scikit-build-core": "https://github.com/scikit-build/scikit-build-core/archive/70fc6207fe58410b287be0c971ff469359dae289.tar.gz",
+    "scikit-build-core": "https://github.com/scikit-build/scikit-build-core/archive/e03e7c88341cf8f64e620e58bfd1eb770d47a18f.tar.gz",
     "pdm-backend": "https://github.com/pdm-project/pdm-backend/archive/refs/tags/2.4.6.tar.gz",
 }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the downstream `scikit-build-core` pin in `noxfile.py` from `70fc620` to current `main` (`e03e7c8`).

## Why

The downstream `scikit-build-core` nox session has been failing on:

```
FutureWarning: tag.strict is not set. Currently defaults to False ...
```

This warning is leaked from `vcs-versioning` 2.x internals and reaches scikit-build-core through its `setuptools_scm` dynamic-metadata plugin. scikit-build-core runs pytest with warnings-as-errors, so the new `FutureWarning` became a hard test failure (`test_plugin_metadata[dynamic_metadata]`).

The fix is upstream in [scikit-build/scikit-build-core#1350](https://github.com/scikit-build/scikit-build-core/pull/1350) ("test: adapt to setuptools-scm 10 / vcs-versioning 2 warnings", 2026-06-22), which adds `filterwarnings` entries demoting that `FutureWarning` (and a related vcs-versioning `DeprecationWarning`) back to `default`. The previous pin (`70fc620`, 2026-06-16) predated that fix.

Nothing in pyproject-metadata itself caused the failure; this is purely a downstream-test pin bump.