### PR TITLE
feat: warn on invalid extra names (PEP 685)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Features:
+
+- Warn ([PEP 685](https://peps.python.org/pep-0685/)) when an extra name in
+  `project.optional-dependencies` is not a valid name. The extra is still
+  emitted, only a `ConfigurationWarning` is produced.
+
 Fixes:
 
 - Error on an unset dynamic version instead of silently writing

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -588,6 +588,7 @@ class StandardMetadata:
         - ``license_files`` can't be used with classic ``license``
         - License classifiers can't be used with SPDX license
         - ``description`` is a single line (warning)
+        - Extra names in "project.optional-dependencies" should be valid (warning)
         - ``license`` is not an SPDX license expression if metadata_version >= 2.4 (warning)
         - License classifiers deprecated for metadata_version >= 2.4 (warning)
         - ``license`` is an SPDX license expression if metadata_version >= 2.4
@@ -640,6 +641,17 @@ class StandardMetadata:
                 elif any(c.startswith("License ::") for c in self.classifiers):
                     warnings.warn(
                         "'License ::' classifiers are deprecated for metadata >= 2.4, use a SPDX license expression for \"project.license\" instead",
+                        ConfigurationWarning,
+                        stacklevel=2,
+                    )
+            for extra in self.optional_dependencies:
+                try:
+                    packaging.utils.canonicalize_name(extra, validate=True)
+                except packaging.utils.InvalidName:  # noqa: PERF203
+                    warnings.warn(
+                        f'Invalid extra name {extra!r} in "project.optional-dependencies". '
+                        "A valid name consists only of ASCII letters and numbers, period, "
+                        "underscore and hyphen. It must start and end with a letter or number",
                         ConfigurationWarning,
                         stacklevel=2,
                     )

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -2214,3 +2214,61 @@ def test_multiline_description_warns() -> None:
                 },
             }
         )
+
+
+@pytest.mark.parametrize("extra", ["my extra", "extra!", "-leading", "trailing_"])
+def test_invalid_extra_name_warns(extra: str) -> None:
+    data = f"""
+        [project]
+        name = "example"
+        version = "1.2.3"
+
+        [project.optional-dependencies]
+        "{extra}" = []
+    """
+    with pytest.warns(
+        pyproject_metadata.errors.ConfigurationWarning,
+        match=re.escape(
+            f'Invalid extra name {extra!r} in "project.optional-dependencies".'
+        ),
+    ):
+        pyproject_metadata.StandardMetadata.from_pyproject(
+            tomllib.loads(textwrap.dedent(data))
+        )
+
+
+@pytest.mark.parametrize("extra", ["test", "My-Extra", "a.b_c"])
+def test_valid_extra_name_no_warning(extra: str) -> None:
+    data = f"""
+        [project]
+        name = "example"
+        version = "1.2.3"
+
+        [project.optional-dependencies]
+        "{extra}" = []
+    """
+    pyproject_metadata.StandardMetadata.from_pyproject(
+        tomllib.loads(textwrap.dedent(data))
+    )
+
+
+def test_invalid_extra_name_warns_once_and_still_emitted() -> None:
+    data = """
+        [project]
+        name = "example"
+        version = "1.2.3"
+
+        [project.optional-dependencies]
+        "my extra" = []
+    """
+    with pytest.warns(
+        pyproject_metadata.errors.ConfigurationWarning,
+        match=re.escape("Invalid extra name 'my extra'"),
+    ):
+        metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+            tomllib.loads(textwrap.dedent(data))
+        )
+
+    # Emitting metadata must not warn again (filterwarnings=error would raise),
+    # and the extra is not dropped.
+    assert "Provides-Extra: my extra" in str(metadata.as_rfc822())


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #285.

PEP 685 says tools SHOULD warn when reading an invalid extra name. `StandardMetadata.validate(warn=True)` now emits a `ConfigurationWarning` for each `project.optional-dependencies` key that is not a valid name per `packaging.utils.canonicalize_name(validate=True)` — the same rule already applied to `project.name`.

The extra is only warned about, **not dropped** — PEP 685's "SHOULD ignore" is reader/installer policy, and a shared metadata library silently dropping data would be worse for backends. Since the warning lives under the `warn=True` gate, it fires once at construction and metadata emission (`validate(warn=False)`) does not warn again.

Tests were written first and confirmed to fail without the fix.