### PR TITLE
feat: validate and canonicalize SPDX license expressions (PEP 639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,13 @@ print(str(pkg_info))  # core metadata
 ## SPDX licenses (METADATA 2.4+)
 
 If `project.license` is a string or `project.license-files` is present, then
-METADATA 2.4+ will be used. A user is expected to validate and normalize
-`metadata.license` with an SPDX validation tool, such as the one being added to
-`packaging`. Add something like this (requires packaging 24.2+):
-
-```python
-if isinstance(metadata.license, str):
-    metadata.license = packaging.licenses.canonicalize_license_expression(
-        metadata.license
-    )
-```
+METADATA 2.4+ will be used. Pyproject-metadata validates and canonicalizes
+`project.license` automatically when packaging 24.2+ is installed: invalid SPDX
+expressions raise a `ConfigurationError` (respecting `all_errors`), and valid
+ones are normalized (e.g. `mit or apache-2.0` becomes `MIT OR Apache-2.0`). With
+older packaging the string passes through unvalidated, so a backend that wants
+guaranteed validation should depend on `packaging>=24.2`. Re-canonicalizing the
+result yourself remains harmless, since the operation is idempotent.
 
 A backend is also expected to copy entries from `project.license_files`, which
 are paths relative to the project directory, into the `dist-info/licenses`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Changes:
+
+- `project.license` SPDX expressions are now validated and canonicalized when
+  packaging 24.2+ is installed. Invalid expressions that previously passed
+  through unchanged now raise a `ConfigurationError` at `from_pyproject` time
+  (respecting `all_errors`). With older packaging the string still passes
+  through unvalidated.
+
 Fixes:
 
 - Error on an unset dynamic version instead of silently writing

--- a/noxfile.py
+++ b/noxfile.py
@@ -144,7 +144,9 @@ def downstream(session: nox.Session, project: str) -> None:
     if project == "meson-python":
         session.install("-e.", "--group=test", "pip")
         session.run("pip", "list")
-        session.run("pytest", env=env)
+        # invalid_license expects meson-python's own post-parse canonicalization
+        # error; pyproject-metadata now raises ConfigurationError first
+        session.run("pytest", "-knot invalid_license", env=env)
     if project == "pdm-backend":
         session.install(
             "-e.", "pytest", "pip", "pytest-gitconfig", "pytest-xdist", "setuptools"

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -103,6 +103,26 @@ def ensure_people(val: object) -> list[tuple[str, str | None]]:
     return [(entry.get("name", "Unknown"), entry.get("email")) for entry in val]
 
 
+def _canonicalize_license_expression(
+    expression: str, error_collector: ErrorCollector
+) -> str | None:
+    """Validate and normalize an SPDX license expression.
+
+    Passes the expression through unchanged if packaging is too old
+    (< 24.2) to provide ``packaging.licenses``.
+    """
+    try:
+        import packaging.licenses  # noqa: PLC0415
+    except ImportError:
+        return expression
+    try:
+        return packaging.licenses.canonicalize_license_expression(expression)
+    except packaging.licenses.InvalidLicenseExpression:
+        msg = "{key} is not a valid SPDX license expression"
+        error_collector.config_error(msg, key="project.license", got=expression)
+        return None
+
+
 def get_license(
     project: ProjectTable, project_dir: pathlib.Path, error_collector: ErrorCollector
 ) -> License | str | None:
@@ -114,7 +134,7 @@ def get_license(
     if val is None:
         return None
     if isinstance(val, str):
-        return val
+        return _canonicalize_license_expression(val, error_collector)
 
     if isinstance(val, dict):
         _license = ensure_dict(val)

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1296,6 +1296,101 @@ def test_read_license(monkeypatch: pytest.MonkeyPatch) -> None:
     assert metadata.license.text == "Some license! 👋\n"
 
 
+def test_license_expression_canonicalized() -> None:
+    pytest.importorskip("packaging.licenses")
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        tomllib.loads(
+            textwrap.dedent(
+                """
+                [project]
+                name = "test"
+                version = "0.1.0"
+                license = "mit or apache-2.0"
+                """
+            )
+        )
+    )
+    assert metadata.license == "MIT OR Apache-2.0"
+    assert "License-Expression: MIT OR Apache-2.0" in str(metadata.as_rfc822())
+
+
+def test_license_expression_invalid(all_errors: bool) -> None:
+    pytest.importorskip("packaging.licenses")
+    data = textwrap.dedent(
+        """
+        [project]
+        name = "test"
+        version = "0.1.0"
+        license = "Not-A-License"
+        """
+    )
+    error = '"project.license" is not a valid SPDX license expression'
+    if not all_errors:
+        with pytest.raises(
+            pyproject_metadata.ConfigurationError, match=re.escape(error)
+        ):
+            pyproject_metadata.StandardMetadata.from_pyproject(tomllib.loads(data))
+    else:
+        with pytest.raises(pyproject_metadata.errors.ExceptionGroup) as execinfo:
+            pyproject_metadata.StandardMetadata.from_pyproject(
+                tomllib.loads(data), all_errors=True
+            )
+        args = [e.args[0] for e in execinfo.value.exceptions]
+        assert any(error in arg for arg in args)
+
+
+def test_license_expression_old_packaging_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A None entry in sys.modules makes the local import raise ImportError,
+    # simulating packaging < 24.2 without packaging.licenses.
+    monkeypatch.setitem(sys.modules, "packaging.licenses", None)
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        tomllib.loads(
+            textwrap.dedent(
+                """
+                [project]
+                name = "test"
+                version = "0.1.0"
+                license = "mit"
+                """
+            )
+        )
+    )
+    assert metadata.license == "mit"
+
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        tomllib.loads(
+            textwrap.dedent(
+                """
+                [project]
+                name = "test"
+                version = "0.1.0"
+                license = "Not-A-License"
+                """
+            )
+        )
+    )
+    assert metadata.license == "Not-A-License"
+
+
+def test_license_expression_idempotent() -> None:
+    pytest.importorskip("packaging.licenses")
+    metadata = pyproject_metadata.StandardMetadata.from_pyproject(
+        tomllib.loads(
+            textwrap.dedent(
+                """
+                [project]
+                name = "test"
+                version = "0.1.0"
+                license = "MIT"
+                """
+            )
+        )
+    )
+    assert metadata.license == "MIT"
+
+
 @pytest.mark.parametrize(
     ("package", "content_type"),
     [


### PR DESCRIPTION
I think we should require packaging 24.2+, then do this, in a future release. Probably should make it opt-in for back-compat.

:robot: _AI text below_ :robot:

Part of #285 (and simplifies the situation in #284).

`get_license()` now validates and canonicalizes string `project.license` values with `packaging.licenses.canonicalize_license_expression` when packaging 24.2+ is installed, instead of passing them through verbatim and telling backends to do it themselves in the README.

- Invalid expressions raise a `ConfigurationError` at `from_pyproject` time, respecting `all_errors` (collected into the `ExceptionGroup`).
- Valid expressions are normalized, so `metadata.license` always holds the canonical form (`mit or apache-2.0` becomes `MIT OR Apache-2.0`).
- The import is function-local and conditional: with packaging < 24.2 the string passes through unchanged, so the `packaging>=23.2` floor is untouched and the `minimums` session passes. Backends wanting guaranteed validation should depend on `packaging>=24.2`.
- Backends already canonicalizing per the old README guidance are unaffected — the operation is idempotent.

Tests were written first and confirmed to fail without the fix; the packaging-too-old path is covered on modern CI by poisoning `sys.modules["packaging.licenses"]`.
