### PR TITLE
feat: promote [project] field taxonomy to public API

### DIFF
--- a/docs/api/pyproject_metadata.rst
+++ b/docs/api/pyproject_metadata.rst
@@ -13,6 +13,36 @@ Submodules
 pyproject\_metadata.constants module
 ------------------------------------
 
+The ``[project]`` field taxonomy in this module is public API for build
+backends and plugin systems. Rather than hand-maintaining a copy of the field
+list, a backend or a dynamic-metadata plugin can import these sets to answer
+three questions:
+
+* **Which fields exist?** ``KNOWN_PROJECT_FIELDS`` is every valid ``[project]``
+  key.
+* **Which fields may a plugin provide dynamically, and which may be extended?**
+  A plugin may fill any field listed in ``project.dynamic``. Per PEP 808, the
+  fields in ``PROJECT_DYNAMIC_STATIC`` may be *both* defined statically and
+  listed as dynamic; a plugin may then add entries to them but must not remove
+  or overwrite the static entries. ``name`` and ``dynamic`` can never be
+  dynamic and are excluded from the shape sets below.
+* **How is a field's value shaped?** The ``PROJECT_*_FIELDS`` sets classify
+  fields by their TOML value shape, so a plugin knows how to construct or merge
+  a value:
+
+  * ``PROJECT_SCALAR_FIELDS`` — a single value (never both static and dynamic).
+  * ``PROJECT_LIST_STR_FIELDS`` — an array of strings.
+  * ``PROJECT_PEOPLE_FIELDS`` — an array of ``name``/``email`` tables.
+  * ``PROJECT_TABLE_FIELDS`` — a flat string-to-string table.
+  * ``PROJECT_OPTIONAL_DEPENDENCIES_FIELDS`` — a table mapping an extra to an
+    array of strings.
+  * ``PROJECT_ENTRY_POINTS_FIELDS`` — a table mapping a group to a
+    string-to-string table.
+
+  Together with ``{"name", "dynamic"}`` these shape sets partition
+  ``KNOWN_PROJECT_FIELDS``, and ``PROJECT_DYNAMIC_STATIC`` is exactly the union
+  of the extendable (array and table) shapes.
+
 .. automodule:: pyproject_metadata.constants
    :members:
    :undoc-members:

--- a/pyproject_metadata/constants.py
+++ b/pyproject_metadata/constants.py
@@ -2,7 +2,19 @@
 
 """
 Constants for the pyproject_metadata package, collected here to make them easy
-to update. These should be considered mostly private.
+to update.
+
+The ``[project]`` field taxonomy is public API. Build backends and plugin
+systems (such as scikit-build-core, meson-python, and
+scikit-build/dynamic-metadata) can import these sets instead of hand-maintaining
+their own copies to decide which fields exist (``KNOWN_PROJECT_FIELDS``), which
+a plugin may set dynamically and which may be extended when both static and
+dynamic per PEP 808 (``PROJECT_DYNAMIC_STATIC``), and how each field's value is
+shaped (the ``PROJECT_*_FIELDS`` shape sets).
+
+The metadata-side sets (``PROJECT_TO_METADATA``, ``KNOWN_METADATA_FIELDS``,
+``KNOWN_MULTIUSE``, and the metadata-version sets) describe the RFC 822 output
+and remain implementation-oriented.
 """
 
 from __future__ import annotations
@@ -17,6 +29,12 @@ __all__ = [
     "PRE_2_6_METADATA_VERSIONS",
     "PRE_SPDX_METADATA_VERSIONS",
     "PROJECT_DYNAMIC_STATIC",
+    "PROJECT_ENTRY_POINTS_FIELDS",
+    "PROJECT_LIST_STR_FIELDS",
+    "PROJECT_OPTIONAL_DEPENDENCIES_FIELDS",
+    "PROJECT_PEOPLE_FIELDS",
+    "PROJECT_SCALAR_FIELDS",
+    "PROJECT_TABLE_FIELDS",
     "PROJECT_TO_METADATA",
 ]
 
@@ -53,24 +71,50 @@ PROJECT_TO_METADATA = {
     "version": frozenset(["Version"]),
 }
 
+# Classification of [project] fields by their TOML value shape. "name" and
+# "dynamic" are excluded from every set below: neither can ever be dynamic.
+# Together these sets partition the remaining KNOWN_PROJECT_FIELDS (see tests).
+
+# Single-value fields. Per PEP 808 these can never be both static and dynamic.
+PROJECT_SCALAR_FIELDS = frozenset(
+    {"version", "description", "requires-python", "license", "readme"}
+)
+
+# Arrays of strings.
+PROJECT_LIST_STR_FIELDS = frozenset(
+    {
+        "classifiers",
+        "keywords",
+        "dependencies",
+        "license-files",
+        "import-names",
+        "import-namespaces",
+    }
+)
+
+# Arrays of tables with "name"/"email" keys.
+PROJECT_PEOPLE_FIELDS = frozenset({"authors", "maintainers"})
+
+# Flat string-to-string tables.
+PROJECT_TABLE_FIELDS = frozenset({"urls", "scripts", "gui-scripts"})
+
+# Table mapping an extra name to an array of strings.
+PROJECT_OPTIONAL_DEPENDENCIES_FIELDS = frozenset({"optional-dependencies"})
+
+# Table mapping a group name to a string-to-string table.
+PROJECT_ENTRY_POINTS_FIELDS = frozenset({"entry-points"})
+
 # Fields PEP 808 allows to be both statically defined and listed in
-# project.dynamic. These are the arrays and tables with arbitrary entries; a
-# backend may extend them but not remove or modify existing entries.
-PROJECT_DYNAMIC_STATIC = {
-    "authors",
-    "classifiers",
-    "dependencies",
-    "entry-points",
-    "gui-scripts",
-    "import-names",
-    "import-namespaces",
-    "keywords",
-    "license-files",
-    "maintainers",
-    "optional-dependencies",
-    "scripts",
-    "urls",
-}
+# project.dynamic: the arrays and tables with arbitrary entries. A backend may
+# extend these entries but not remove or modify existing ones. Derived from the
+# shape sets so it stays consistent with the taxonomy by construction.
+PROJECT_DYNAMIC_STATIC = (
+    PROJECT_LIST_STR_FIELDS
+    | PROJECT_PEOPLE_FIELDS
+    | PROJECT_TABLE_FIELDS
+    | PROJECT_OPTIONAL_DEPENDENCIES_FIELDS
+    | PROJECT_ENTRY_POINTS_FIELDS
+)
 
 KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}
 KNOWN_BUILD_SYSTEM_FIELDS = {"backend-path", "build-backend", "requires"}

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import typing
 
@@ -24,6 +26,36 @@ def test_project_table_all() -> None:
     import pyproject_metadata.project_table  # noqa: PLC0415
 
     assert "annotations" not in dir(pyproject_metadata.project_table)
+
+
+def test_project_field_taxonomy_partitions() -> None:
+    constants = pyproject_metadata.constants
+    shape_sets = [
+        constants.PROJECT_SCALAR_FIELDS,
+        constants.PROJECT_LIST_STR_FIELDS,
+        constants.PROJECT_PEOPLE_FIELDS,
+        constants.PROJECT_TABLE_FIELDS,
+        constants.PROJECT_OPTIONAL_DEPENDENCIES_FIELDS,
+        constants.PROJECT_ENTRY_POINTS_FIELDS,
+        frozenset({"name", "dynamic"}),
+    ]
+    union: set[str] = set()
+    for shape in shape_sets:
+        assert union.isdisjoint(shape)
+        union |= shape
+    assert union == constants.KNOWN_PROJECT_FIELDS
+
+
+def test_project_dynamic_static_is_extendable_shapes() -> None:
+    constants = pyproject_metadata.constants
+    assert constants.PROJECT_DYNAMIC_STATIC == (
+        constants.PROJECT_LIST_STR_FIELDS
+        | constants.PROJECT_PEOPLE_FIELDS
+        | constants.PROJECT_TABLE_FIELDS
+        | constants.PROJECT_OPTIONAL_DEPENDENCIES_FIELDS
+        | constants.PROJECT_ENTRY_POINTS_FIELDS
+    )
+    assert constants.PROJECT_DYNAMIC_STATIC.isdisjoint(constants.PROJECT_SCALAR_FIELDS)
 
 
 def test_get_name() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Motivation

Build backends (scikit-build-core, meson-python) and the
scikit-build/dynamic-metadata plugin system all need to know the `[project]`
field taxonomy: which keys exist, which a plugin may set dynamically, which may
be *both* static and dynamic per PEP 808, and how each field's value is shaped.
Today they hand-maintain their own copies, and those copies drift — for
example dynamic-metadata's `info.py` is already missing `import-names` /
`import-namespaces`.

This promotes the taxonomy in `pyproject_metadata.constants` to documented
public API so those projects can import it instead of duplicating it.

## What changed

New field-shape sets, classifying every `[project]` field by its TOML value
shape (`name` and `dynamic` are excluded — neither can ever be dynamic):

- `PROJECT_SCALAR_FIELDS` = `{version, description, requires-python, license, readme}` — single values; per PEP 808 never both static and dynamic.
- `PROJECT_LIST_STR_FIELDS` = `{classifiers, keywords, dependencies, license-files, import-names, import-namespaces}` — arrays of strings.
- `PROJECT_PEOPLE_FIELDS` = `{authors, maintainers}` — arrays of name/email tables.
- `PROJECT_TABLE_FIELDS` = `{urls, scripts, gui-scripts}` — flat string-to-string tables.
- `PROJECT_OPTIONAL_DEPENDENCIES_FIELDS` = `{optional-dependencies}` — table of arrays of strings.
- `PROJECT_ENTRY_POINTS_FIELDS` = `{entry-points}` — table of string-to-string tables.

### Consistency by construction

`PROJECT_DYNAMIC_STATIC` (the PEP 808 both-static-and-dynamic set) is now
**derived** as the union of the extendable shapes (list-str ∪ people ∪ table ∪
optional-dependencies ∪ entry-points) rather than a hand-written literal. Its
value is unchanged. A new test asserts the shape sets plus `{name, dynamic}`
partition `KNOWN_PROJECT_FIELDS` and are pairwise disjoint, so the taxonomy
can't silently drift as new fields are added.

The module docstring, `__all__`, and the Sphinx API reference (`docs/api/`) are
updated: the field-shape sets and `PROJECT_DYNAMIC_STATIC` are blessed as
public API with prose aimed at backend authors, while the metadata-side sets
(`PROJECT_TO_METADATA`, `KNOWN_METADATA_FIELDS`, `KNOWN_MULTIUSE`, version sets)
remain implementation-oriented.

## Testing

- `prek -a --quiet` — clean
- `uv run noxfile.py -s mypy` — clean (Python 3.8 strict)
- `uv run pytest` — 310 passed, 87 skipped
- `uv run noxfile.py -s docs` — builds; the 26 warnings are all pre-existing
  autodoc issues with dash-named `project_table` TypedDict keys, unrelated to
  this change.
