### PR TITLE
feat: add PEP 808 merge_dynamic helper

### DIFF
--- a/docs/api/pyproject_metadata.rst
+++ b/docs/api/pyproject_metadata.rst
@@ -48,6 +48,30 @@ three questions:
    :undoc-members:
    :show-inheritance:
 
+pyproject\_metadata.dynamic module
+----------------------------------
+
+A build backend that runs a dynamic-metadata plugin gets back only the plugin's
+*additions* for a field. :func:`~pyproject_metadata.merge_dynamic` applies those
+additions on top of whatever the user declared statically, using the PEP 808
+merge rules keyed off the field's shape (see the taxonomy above), so backends do
+not each re-derive them. Values are raw ``[project]`` data as parsed from
+``pyproject.toml``:
+
+.. code-block:: python
+
+   from pyproject_metadata import merge_dynamic
+
+   static = {"test": ["pytest"]}
+   plugin_result = {"test": ["coverage"], "docs": ["sphinx"]}
+   merged = merge_dynamic("optional-dependencies", static, plugin_result)
+   # {"test": ["pytest", "coverage"], "docs": ["sphinx"]}
+
+.. automodule:: pyproject_metadata.dynamic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pyproject\_metadata.errors module
 ---------------------------------
 

--- a/docs/api/pyproject_metadata.rst
+++ b/docs/api/pyproject_metadata.rst
@@ -13,6 +13,36 @@ Submodules
 pyproject\_metadata.constants module
 ------------------------------------
 
+The ``[project]`` field taxonomy in this module is public API for build
+backends and plugin systems. Rather than hand-maintaining a copy of the field
+list, a backend or a dynamic-metadata plugin can import these sets to answer
+three questions:
+
+* **Which fields exist?** ``KNOWN_PROJECT_FIELDS`` is every valid ``[project]``
+  key.
+* **Which fields may a plugin provide dynamically, and which may be extended?**
+  A plugin may fill any field listed in ``project.dynamic``. Per PEP 808, the
+  fields in ``PROJECT_DYNAMIC_STATIC`` may be *both* defined statically and
+  listed as dynamic; a plugin may then add entries to them but must not remove
+  or overwrite the static entries. ``name`` and ``dynamic`` can never be
+  dynamic and are excluded from the shape sets below.
+* **How is a field's value shaped?** The ``PROJECT_*_FIELDS`` sets classify
+  fields by their TOML value shape, so a plugin knows how to construct or merge
+  a value:
+
+  * ``PROJECT_SCALAR_FIELDS`` — a single value (never both static and dynamic).
+  * ``PROJECT_LIST_STR_FIELDS`` — an array of strings.
+  * ``PROJECT_PEOPLE_FIELDS`` — an array of ``name``/``email`` tables.
+  * ``PROJECT_TABLE_FIELDS`` — a flat string-to-string table.
+  * ``PROJECT_OPTIONAL_DEPENDENCIES_FIELDS`` — a table mapping an extra to an
+    array of strings.
+  * ``PROJECT_ENTRY_POINTS_FIELDS`` — a table mapping a group to a
+    string-to-string table.
+
+  Together with ``{"name", "dynamic"}`` these shape sets partition
+  ``KNOWN_PROJECT_FIELDS``, and ``PROJECT_DYNAMIC_STATIC`` is exactly the union
+  of the extendable (array and table) shapes.
+
 .. automodule:: pyproject_metadata.constants
    :members:
    :undoc-members:

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -50,6 +50,7 @@ import warnings
 
 # Build backends may vendor this package, so all imports are relative.
 from . import constants, pyproject
+from .dynamic import merge_dynamic
 from .errors import ConfigurationError, ConfigurationWarning, ErrorCollector
 from .project_table import to_project_table
 from .pyproject import License, Readme
@@ -90,6 +91,7 @@ __all__ = [
     "extras_project",
     "extras_top_level",
     "field_to_metadata",
+    "merge_dynamic",
 ]
 
 

--- a/pyproject_metadata/constants.py
+++ b/pyproject_metadata/constants.py
@@ -2,7 +2,19 @@
 
 """
 Constants for the pyproject_metadata package, collected here to make them easy
-to update. These should be considered mostly private.
+to update.
+
+The ``[project]`` field taxonomy is public API. Build backends and plugin
+systems (such as scikit-build-core, meson-python, and
+scikit-build/dynamic-metadata) can import these sets instead of hand-maintaining
+their own copies to decide which fields exist (``KNOWN_PROJECT_FIELDS``), which
+a plugin may set dynamically and which may be extended when both static and
+dynamic per PEP 808 (``PROJECT_DYNAMIC_STATIC``), and how each field's value is
+shaped (the ``PROJECT_*_FIELDS`` shape sets).
+
+The metadata-side sets (``PROJECT_TO_METADATA``, ``KNOWN_METADATA_FIELDS``,
+``KNOWN_MULTIUSE``, and the metadata-version sets) describe the RFC 822 output
+and remain implementation-oriented.
 """
 
 from __future__ import annotations
@@ -17,6 +29,12 @@ __all__ = [
     "PRE_2_6_METADATA_VERSIONS",
     "PRE_SPDX_METADATA_VERSIONS",
     "PROJECT_DYNAMIC_STATIC",
+    "PROJECT_ENTRY_POINTS_FIELDS",
+    "PROJECT_LIST_STR_FIELDS",
+    "PROJECT_OPTIONAL_DEPENDENCIES_FIELDS",
+    "PROJECT_PEOPLE_FIELDS",
+    "PROJECT_SCALAR_FIELDS",
+    "PROJECT_TABLE_FIELDS",
     "PROJECT_TO_METADATA",
 ]
 
@@ -53,24 +71,50 @@ PROJECT_TO_METADATA = {
     "version": frozenset(["Version"]),
 }
 
+# Classification of [project] fields by their TOML value shape. "name" and
+# "dynamic" are excluded from every set below: neither can ever be dynamic.
+# Together these sets partition the remaining KNOWN_PROJECT_FIELDS (see tests).
+
+# Single-value fields. Per PEP 808 these can never be both static and dynamic.
+PROJECT_SCALAR_FIELDS = frozenset(
+    {"version", "description", "requires-python", "license", "readme"}
+)
+
+# Arrays of strings.
+PROJECT_LIST_STR_FIELDS = frozenset(
+    {
+        "classifiers",
+        "keywords",
+        "dependencies",
+        "license-files",
+        "import-names",
+        "import-namespaces",
+    }
+)
+
+# Arrays of tables with "name"/"email" keys.
+PROJECT_PEOPLE_FIELDS = frozenset({"authors", "maintainers"})
+
+# Flat string-to-string tables.
+PROJECT_TABLE_FIELDS = frozenset({"urls", "scripts", "gui-scripts"})
+
+# Table mapping an extra name to an array of strings.
+PROJECT_OPTIONAL_DEPENDENCIES_FIELDS = frozenset({"optional-dependencies"})
+
+# Table mapping a group name to a string-to-string table.
+PROJECT_ENTRY_POINTS_FIELDS = frozenset({"entry-points"})
+
 # Fields PEP 808 allows to be both statically defined and listed in
-# project.dynamic. These are the arrays and tables with arbitrary entries; a
-# backend may extend them but not remove or modify existing entries.
-PROJECT_DYNAMIC_STATIC = {
-    "authors",
-    "classifiers",
-    "dependencies",
-    "entry-points",
-    "gui-scripts",
-    "import-names",
-    "import-namespaces",
-    "keywords",
-    "license-files",
-    "maintainers",
-    "optional-dependencies",
-    "scripts",
-    "urls",
-}
+# project.dynamic: the arrays and tables with arbitrary entries. A backend may
+# extend these entries but not remove or modify existing ones. Derived from the
+# shape sets so it stays consistent with the taxonomy by construction.
+PROJECT_DYNAMIC_STATIC = (
+    PROJECT_LIST_STR_FIELDS
+    | PROJECT_PEOPLE_FIELDS
+    | PROJECT_TABLE_FIELDS
+    | PROJECT_OPTIONAL_DEPENDENCIES_FIELDS
+    | PROJECT_ENTRY_POINTS_FIELDS
+)
 
 KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}
 KNOWN_BUILD_SYSTEM_FIELDS = {"backend-path", "build-backend", "requires"}

--- a/pyproject_metadata/dynamic.py
+++ b/pyproject_metadata/dynamic.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+
+"""
+PEP 808 dynamic-metadata merge helper.
+
+Build backends and plugin loaders (such as scikit-build-core, meson-python, and
+scikit-build/dynamic-metadata) use :func:`merge_dynamic` to combine a statically
+declared ``[project]`` field value with a dynamically computed addition,
+following the rules of :pep:`808`. This gives every backend a single,
+spec-conformant implementation of the merge instead of each re-deriving it.
+
+Values are raw TOML-shaped ``[project]`` data -- the strings, lists, and dicts
+as they appear in ``pyproject.toml`` -- not the parsed types on
+:class:`~pyproject_metadata.StandardMetadata`.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from . import constants
+from .errors import ConfigurationError, ConfigurationTypeError
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+__all__ = ["merge_dynamic"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _key(field: str) -> str:
+    return f"project.{field}"
+
+
+def _as_list(field: str, value: Any) -> list[Any]:  # noqa: ANN401
+    if not isinstance(value, list):
+        msg = f'Field "{_key(field)}" has an invalid type, expecting a list (got {type(value).__name__})'
+        raise ConfigurationTypeError(msg, key=_key(field))
+    return value
+
+
+def _as_table(field: str, value: Any) -> dict[str, Any]:  # noqa: ANN401
+    if not isinstance(value, dict):
+        msg = f'Field "{_key(field)}" has an invalid type, expecting a table (got {type(value).__name__})'
+        raise ConfigurationTypeError(msg, key=_key(field))
+    return value
+
+
+def _merge_table(
+    location: str, static: Mapping[str, Any], additions: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Add-only merge of a flat table; a provider may add keys but may not
+    modify the value of a key that already exists (re-adding the identical value
+    is allowed).
+    """
+    merged = dict(static)
+    for name, value in additions.items():
+        if name in merged and merged[name] != value:
+            msg = (
+                f'Dynamic addition to "{location}" may not modify existing key "{name}"'
+            )
+            raise ConfigurationError(msg, key=location)
+        merged[name] = value
+    return merged
+
+
+def merge_dynamic(field: str, static: Any, additions: Any) -> Any:  # noqa: ANN401
+    """
+    Merge a dynamically computed *addition* into a statically declared
+    ``[project]`` field value, per :pep:`808`.
+
+    Intended for build backends and dynamic-metadata plugin loaders. The static
+    value is always preserved and kept first; ``additions`` holds only what a
+    provider contributes. Inputs and the return value are raw TOML-shaped
+    ``[project]`` values (see the module docstring), not parsed metadata.
+
+    The merge depends on the field's shape (see
+    :mod:`pyproject_metadata.constants`):
+
+    * list fields (``PROJECT_LIST_STR_FIELDS``, ``PROJECT_PEOPLE_FIELDS``) are
+      concatenated verbatim -- duplicates are allowed.
+    * flat tables (``PROJECT_TABLE_FIELDS``: ``urls``, ``scripts``,
+      ``gui-scripts``) are an add-only merge: a new key is added, re-adding a key
+      with its existing value is a no-op, and adding a key with a *different*
+      value raises.
+    * ``optional-dependencies`` merges per extra: new extras are added and an
+      existing extra's dependency list is extended.
+    * ``entry-points`` merges per group: new groups are added and an existing
+      group is merged with the same add-only rule as a flat table.
+
+    :raises ConfigurationError: if ``field`` is not a known ``[project]`` field,
+        if it is a scalar field or ``name``/``dynamic`` (which PEP 808 forbids
+        from being given both statically and dynamically), or if an add-only
+        merge would modify an existing table key.
+    :raises ConfigurationTypeError: if ``static`` or ``additions`` do not have
+        the shape the field requires (e.g. a list field given a non-list).
+    """
+    if field not in constants.KNOWN_PROJECT_FIELDS:
+        msg = f'Field "{_key(field)}" is not a known [project] field'
+        raise ConfigurationError(msg, key=_key(field))
+
+    if field not in constants.PROJECT_DYNAMIC_STATIC:
+        msg = f'Field "{_key(field)}" cannot be given both statically and dynamically'
+        raise ConfigurationError(msg, key=_key(field))
+
+    if field in constants.PROJECT_LIST_STR_FIELDS | constants.PROJECT_PEOPLE_FIELDS:
+        return [*_as_list(field, static), *_as_list(field, additions)]
+
+    if field in constants.PROJECT_TABLE_FIELDS:
+        return _merge_table(
+            _key(field), _as_table(field, static), _as_table(field, additions)
+        )
+
+    if field in constants.PROJECT_OPTIONAL_DEPENDENCIES_FIELDS:
+        static_extras = _as_table(field, static)
+        addition_extras = _as_table(field, additions)
+        merged = {
+            extra: [*_as_list(field, deps)] for extra, deps in static_extras.items()
+        }
+        for extra, deps in addition_extras.items():
+            merged.setdefault(extra, []).extend(_as_list(field, deps))
+        return merged
+
+    # entry-points: the only remaining shape (PROJECT_ENTRY_POINTS_FIELDS).
+    static_groups = _as_table(field, static)
+    addition_groups = _as_table(field, additions)
+    merged_groups = {group: dict(eps) for group, eps in static_groups.items()}
+    for group, eps in addition_groups.items():
+        merged_groups[group] = _merge_table(
+            f"{_key(field)}.{group}",
+            merged_groups.get(group, {}),
+            _as_table(field, eps),
+        )
+    return merged_groups

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import pytest
+
+import pyproject_metadata
+from pyproject_metadata.dynamic import merge_dynamic
+from pyproject_metadata.errors import ConfigurationError, ConfigurationTypeError
+
+
+def test_reexported_from_top_level() -> None:
+    assert pyproject_metadata.merge_dynamic is merge_dynamic
+    assert "merge_dynamic" in dir(pyproject_metadata)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["dependencies", "classifiers", "keywords", "license-files"],
+)
+def test_list_str_concatenation(field: str) -> None:
+    assert merge_dynamic(field, ["a", "b"], ["c"]) == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize("field", ["authors", "maintainers"])
+def test_people_concatenation(field: str) -> None:
+    static = [{"name": "A", "email": "a@x"}]
+    additions = [{"name": "B"}]
+    assert merge_dynamic(field, static, additions) == [*static, *additions]
+
+
+def test_list_duplicates_allowed() -> None:
+    assert merge_dynamic("dependencies", ["a"], ["a"]) == ["a", "a"]
+
+
+def test_list_empty_additions() -> None:
+    assert merge_dynamic("dependencies", ["a", "b"], []) == ["a", "b"]
+
+
+def test_list_ordering_static_first() -> None:
+    assert merge_dynamic("keywords", ["z"], ["a"]) == ["z", "a"]
+
+
+@pytest.mark.parametrize("field", ["urls", "scripts", "gui-scripts"])
+def test_table_add_only(field: str) -> None:
+    static = {"Home": "https://example.com"}
+    additions = {"Docs": "https://docs.example.com"}
+    assert merge_dynamic(field, static, additions) == {
+        "Home": "https://example.com",
+        "Docs": "https://docs.example.com",
+    }
+
+
+def test_table_identical_readd_allowed() -> None:
+    static = {"Home": "https://example.com"}
+    assert merge_dynamic("urls", static, {"Home": "https://example.com"}) == static
+
+
+def test_table_empty_additions() -> None:
+    static = {"Home": "https://example.com"}
+    assert merge_dynamic("urls", static, {}) == static
+
+
+def test_table_conflict_raises() -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        merge_dynamic("urls", {"Home": "a"}, {"Home": "b"})
+    assert exc.value.key == "project.urls"
+    assert "may not modify existing key" in str(exc.value)
+    assert "Home" in str(exc.value)
+
+
+def test_optional_dependencies_new_and_extended() -> None:
+    static = {"test": ["pytest"]}
+    additions = {"test": ["coverage"], "docs": ["sphinx"]}
+    assert merge_dynamic("optional-dependencies", static, additions) == {
+        "test": ["pytest", "coverage"],
+        "docs": ["sphinx"],
+    }
+
+
+def test_optional_dependencies_does_not_mutate_input() -> None:
+    static = {"test": ["pytest"]}
+    merge_dynamic("optional-dependencies", static, {"test": ["coverage"]})
+    assert static == {"test": ["pytest"]}
+
+
+def test_entry_points_new_group() -> None:
+    static = {"console_scripts": {"foo": "pkg:foo"}}
+    additions = {"pytest11": {"myplugin": "pkg.plugin"}}
+    assert merge_dynamic("entry-points", static, additions) == {
+        "console_scripts": {"foo": "pkg:foo"},
+        "pytest11": {"myplugin": "pkg.plugin"},
+    }
+
+
+def test_entry_points_extend_existing_group() -> None:
+    static = {"console_scripts": {"foo": "pkg:foo"}}
+    additions = {"console_scripts": {"bar": "pkg:bar"}}
+    assert merge_dynamic("entry-points", static, additions) == {
+        "console_scripts": {"foo": "pkg:foo", "bar": "pkg:bar"},
+    }
+
+
+def test_entry_points_identical_readd_allowed() -> None:
+    static = {"console_scripts": {"foo": "pkg:foo"}}
+    assert (
+        merge_dynamic("entry-points", static, {"console_scripts": {"foo": "pkg:foo"}})
+        == static
+    )
+
+
+def test_entry_points_conflict_identifies_group() -> None:
+    static = {"console_scripts": {"foo": "pkg:foo"}}
+    with pytest.raises(ConfigurationError) as exc:
+        merge_dynamic("entry-points", static, {"console_scripts": {"foo": "pkg:bar"}})
+    assert exc.value.key == "project.entry-points.console_scripts"
+    assert "console_scripts" in str(exc.value)
+    assert "foo" in str(exc.value)
+
+
+def test_entry_points_does_not_mutate_input() -> None:
+    static = {"console_scripts": {"foo": "pkg:foo"}}
+    merge_dynamic("entry-points", static, {"console_scripts": {"bar": "pkg:bar"}})
+    assert static == {"console_scripts": {"foo": "pkg:foo"}}
+
+
+@pytest.mark.parametrize(
+    "field", ["version", "description", "requires-python", "license", "readme"]
+)
+def test_scalar_field_raises(field: str) -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        merge_dynamic(field, "1.0", "2.0")
+    assert exc.value.key == f"project.{field}"
+    assert "cannot be given both statically and dynamically" in str(exc.value)
+
+
+@pytest.mark.parametrize("field", ["name", "dynamic"])
+def test_name_and_dynamic_raise(field: str) -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        merge_dynamic(field, "x", "y")
+    assert "cannot be given both statically and dynamically" in str(exc.value)
+
+
+def test_unknown_field_raises() -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        merge_dynamic("not-a-field", [], [])
+    assert exc.value.key == "project.not-a-field"
+    assert "not a known [project] field" in str(exc.value)
+
+
+def test_list_field_wrong_type_raises() -> None:
+    with pytest.raises(ConfigurationTypeError) as exc:
+        merge_dynamic("dependencies", "notalist", [])
+    assert exc.value.key == "project.dependencies"
+    assert "invalid type" in str(exc.value)
+
+
+def test_table_field_wrong_type_raises() -> None:
+    with pytest.raises(ConfigurationTypeError):
+        merge_dynamic("urls", [], {})
+
+
+def test_optional_dependencies_wrong_inner_type_raises() -> None:
+    with pytest.raises(ConfigurationTypeError):
+        merge_dynamic("optional-dependencies", {"test": "notalist"}, {})
+
+
+def test_entry_points_wrong_inner_type_raises() -> None:
+    with pytest.raises(ConfigurationTypeError):
+        merge_dynamic("entry-points", {}, {"console_scripts": "notatable"})

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import typing
 
@@ -24,6 +26,36 @@ def test_project_table_all() -> None:
     import pyproject_metadata.project_table  # noqa: PLC0415
 
     assert "annotations" not in dir(pyproject_metadata.project_table)
+
+
+def test_project_field_taxonomy_partitions() -> None:
+    constants = pyproject_metadata.constants
+    shape_sets = [
+        constants.PROJECT_SCALAR_FIELDS,
+        constants.PROJECT_LIST_STR_FIELDS,
+        constants.PROJECT_PEOPLE_FIELDS,
+        constants.PROJECT_TABLE_FIELDS,
+        constants.PROJECT_OPTIONAL_DEPENDENCIES_FIELDS,
+        constants.PROJECT_ENTRY_POINTS_FIELDS,
+        frozenset({"name", "dynamic"}),
+    ]
+    union: set[str] = set()
+    for shape in shape_sets:
+        assert union.isdisjoint(shape)
+        union |= shape
+    assert union == constants.KNOWN_PROJECT_FIELDS
+
+
+def test_project_dynamic_static_is_extendable_shapes() -> None:
+    constants = pyproject_metadata.constants
+    assert constants.PROJECT_DYNAMIC_STATIC == (
+        constants.PROJECT_LIST_STR_FIELDS
+        | constants.PROJECT_PEOPLE_FIELDS
+        | constants.PROJECT_TABLE_FIELDS
+        | constants.PROJECT_OPTIONAL_DEPENDENCIES_FIELDS
+        | constants.PROJECT_ENTRY_POINTS_FIELDS
+    )
+    assert constants.PROJECT_DYNAMIC_STATIC.isdisjoint(constants.PROJECT_SCALAR_FIELDS)
 
 
 def test_get_name() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

> [!IMPORTANT]
> **Stacked on #325** ("public field taxonomy constants"). Until #325 merges, its commit appears in this diff too — review only the top commit (`feat: add PEP 808 merge_dynamic helper`).

## Motivation

Build backends (scikit-build-core, meson-python) and the scikit-build/dynamic-metadata plugin loader all need to apply a dynamically-computed *addition* to a statically-declared `[project]` field, following the [PEP 808](https://peps.python.org/pep-0808/) merge rules. Today each re-implements those rules. This adds one shared, spec-conformant implementation in the library that already owns the field taxonomy.

## API

```python
from pyproject_metadata import merge_dynamic

merge_dynamic(field: str, static: Any, additions: Any) -> Any
```

Operates on raw TOML-shaped `[project]` values (strings/lists/dicts as they appear in `pyproject.toml`), not `StandardMetadata`'s parsed types. The static value is preserved and kept first; a provider supplies only its additions. It dispatches on the shape sets from #325 (`pyproject_metadata.constants`):

- **list fields** (`PROJECT_LIST_STR_FIELDS`, `PROJECT_PEOPLE_FIELDS`) → concatenation `[*static, *additions]`, duplicates allowed.
- **flat tables** (`PROJECT_TABLE_FIELDS`: urls, scripts, gui-scripts) → add-only merge; re-adding an identical value is a no-op, adding a key with a *different* value raises.
- **optional-dependencies** → per-extra merge; new extras added, existing extras' lists extended.
- **entry-points** → per-group merge; new groups added, existing groups get the add-only table merge (the error identifies the group).

## Design notes

- **Placement:** new `pyproject_metadata/dynamic.py`, re-exported from `pyproject_metadata` and added to `__all__` (alongside `field_to_metadata`).
- **Errors:** matches the library's existing conventions. A scalar field, `name`/`dynamic`, or an unknown field raises `ConfigurationError` ("cannot be given both statically and dynamically" / "is not a known [project] field"); an add-only conflict raises `ConfigurationError` ("may not modify existing key"). Shape mismatches (e.g. a list field given a non-list) raise `ConfigurationTypeError`. All carry a `key="project.<field>"` location, since these values come from a backend/plugin rather than a file.
- **Type checking:** light isinstance guards only (list-shaped inputs must be lists, table-shaped must be dicts) — consistent with the rest of the library; full validation stays `from_pyproject`'s job.
- Semantics mirror `_merge_metadata`/`_merge_dict` in scikit-build/dynamic-metadata (independently written, not copied).

## Tests & docs

- New `tests/test_dynamic.py` covers every shape branch, all error cases, identical-value re-add, empty additions, static-first ordering, and input non-mutation.
- Documented in the Sphinx API reference with a usage example, following #325's constants prose.
