### PR TITLE
fix: resolve typing errors surfaced by strict downstream mypy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ ALL_PYTHONS = nox.project.python_versions(PYPROJECT)
 ALL_PYTHONS += ["pypy-3.11"]
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.10")
 def mypy(session: nox.Session) -> None:
     """
     Run a type checker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ testpaths = ["tests"]
 [tool.mypy]
 strict = true
 warn_unreachable = false
+python_version = "3.10"
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 files = ["pyproject_metadata", "tests", "noxfile.py"]
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -460,12 +460,16 @@ class StandardMetadata:
 
         dual_dynamic: set[str] = set()
         for field in dynamic:
-            if field in data["project"]:
-                if field in constants.PROJECT_DYNAMIC_STATIC:
-                    dual_dynamic.add(field)
-                elif field != "name":
+            # ``dynamic`` is validated separately with error collection, so the
+            # raw list may still contain values outside the Dynamic literal
+            # (e.g. the invalid "name"); treat it as a plain string here.
+            field_str: str = field
+            if field_str in data["project"]:
+                if field_str in constants.PROJECT_DYNAMIC_STATIC:
+                    dual_dynamic.add(field_str)
+                elif field_str != "name":
                     msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
-                    error_collector.config_error(msg, key=f"project.{field}")
+                    error_collector.config_error(msg, key=f"project.{field_str}")
 
         name = pyproject.ensure_str(project.get("name")) or "UNKNOWN"
 

--- a/pyproject_metadata/project_table.py
+++ b/pyproject_metadata/project_table.py
@@ -411,7 +411,7 @@ def _cast(
     args = typing.get_args(type_hint)
 
     # Any accepts everything, so no validation
-    if type_hint is Any:  # type: ignore[comparison-overlap]
+    if type_hint is Any:
         validate_via_prefix(prefix, data, error_collector)
         return
 

--- a/pyproject_metadata/pyproject.py
+++ b/pyproject_metadata/pyproject.py
@@ -145,7 +145,7 @@ def get_license(
 
 
 def get_license_files(
-    project: dict[str, Any], project_dir: pathlib.Path, error_collector: ErrorCollector
+    project: ProjectTable, project_dir: pathlib.Path, error_collector: ErrorCollector
 ) -> list[pathlib.Path] | None:
     """Get the license-files list of files from the project table.
 
@@ -162,7 +162,7 @@ def get_license_files(
 
 
 def get_readme(  # noqa: C901
-    project: dict[str, Any], project_dir: pathlib.Path, error_collector: ErrorCollector
+    project: ProjectTable, project_dir: pathlib.Path, error_collector: ErrorCollector
 ) -> Readme | None:
     """Get the text of the readme from the project table.
 
@@ -233,7 +233,7 @@ def get_readme(  # noqa: C901
     return Readme(text, file, content_type)
 
 
-def get_dependencies(project: dict[str, Any]) -> list[Requirement]:
+def get_dependencies(project: ProjectTable) -> list[Requirement]:
     """Get the dependencies from the project table."""
     requirement_strings: list[str] | None = None
     requirement_strings_raw = project.get("dependencies")
@@ -253,7 +253,7 @@ def get_dependencies(project: dict[str, Any]) -> list[Requirement]:
 
 
 def get_optional_dependencies(
-    project: dict[str, Any],
+    project: ProjectTable,
 ) -> dict[str, list[Requirement]]:
     """Get the optional dependencies from the project table."""
     val = project.get("optional-dependencies")
@@ -278,7 +278,7 @@ def get_optional_dependencies(
     return requirements_dict
 
 
-def get_entrypoints(project: dict[str, Any]) -> dict[str, dict[str, str]]:
+def get_entrypoints(project: ProjectTable) -> dict[str, dict[str, str]]:
     """Get the entrypoints from the project table."""
     val = project.get("entry-points")
     if val is None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Vendoring this package into scikit-build-core and type-checking it there (mypy 2.x, `python_version = "3.10"`, strict) surfaced 7 typing errors in the PEP 808 code that this repo's own mypy never saw. The reason: the `mypy` nox session pinned the checker to Python 3.8, which pulls the last 3.8-compatible mypy (1.14.1), while mypy 2.x refuses any target below 3.10 and is stricter.

**Tightening (to catch this going forward):**
- Run the `mypy` session under Python 3.10 (so it uses mypy 2.x).
- Set `python_version = "3.10"` in `[tool.mypy]` to pin the target explicitly.

**Fixes:**
- Widen the `get_*` helper signatures in `pyproject.py` from `dict[str, Any]` to `ProjectTable` (matching `get_license`), so the `ProjectTable` cast in `from_pyproject` is assignable. These helpers only read the mapping.
- Read the `dynamic` loop field as a plain `str`: with error collection the raw list can still contain values outside the `Dynamic` literal (e.g. the invalid `"name"`) that the existing defensive check guards against.
- Drop the now-unused `comparison-overlap` ignore on `type_hint is Any`.

Runtime behavior is unchanged; all 403 tests pass.