### PR TITLE
fix: collect config error on unhashable project.dynamic entry

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+Fixes:
+
+- Collect a config error instead of raising a raw `TypeError` when
+  `project.dynamic` contains a non-string (unhashable) entry with
+  `all_errors=True`.
+
 ## 0.12.0 (7-3-2026)
 
 Features:

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -466,12 +466,13 @@ class StandardMetadata:
             # that is not a string and let that validation report it.
             if not isinstance(field, str):
                 continue
-            if field in data["project"]:
-                if field in constants.PROJECT_DYNAMIC_STATIC:
-                    dual_dynamic.add(field)
-                elif field != "name":
+            field_str: str = field
+            if field_str in data["project"]:
+                if field_str in constants.PROJECT_DYNAMIC_STATIC:
+                    dual_dynamic.add(field_str)
+                elif field_str != "name":
                     msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
-                    error_collector.config_error(msg, key=f"project.{field}")
+                    error_collector.config_error(msg, key=f"project.{field_str}")
 
         name = pyproject.ensure_str(project.get("name")) or "UNKNOWN"
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -462,14 +462,16 @@ class StandardMetadata:
         for field in dynamic:
             # ``dynamic`` is validated separately with error collection, so the
             # raw list may still contain values outside the Dynamic literal
-            # (e.g. the invalid "name"); treat it as a plain string here.
-            field_str: str = field
-            if field_str in data["project"]:
-                if field_str in constants.PROJECT_DYNAMIC_STATIC:
-                    dual_dynamic.add(field_str)
-                elif field_str != "name":
+            # (e.g. the invalid "name" or a non-string entry); skip anything
+            # that is not a string and let that validation report it.
+            if not isinstance(field, str):
+                continue
+            if field in data["project"]:
+                if field in constants.PROJECT_DYNAMIC_STATIC:
+                    dual_dynamic.add(field)
+                elif field != "name":
                     msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
-                    error_collector.config_error(msg, key=f"project.{field_str}")
+                    error_collector.config_error(msg, key=f"project.{field}")
 
         name = pyproject.ensure_str(project.get("name")) or "UNKNOWN"
 

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -969,6 +969,24 @@ def test_load(
                 [project]
                 name = "test"
                 version = "0.1.0"
+                dynamic = [
+                    [ "nested" ],
+                ]
+            """,
+            [
+                "Field \"project.dynamic[0]\" expected one of 'authors', 'classifiers', "
+                "'dependencies', 'description', 'entry-points', 'gui-scripts', "
+                "'import-names', 'import-namespaces', 'keywords', 'license', 'license-files', "
+                "'maintainers', 'optional-dependencies', 'readme', 'requires-python', "
+                "'scripts', 'urls', 'version' (got ['nested'])",
+            ],
+            id="Unhashable type in project.dynamic",
+        ),
+        pytest.param(
+            """
+                [project]
+                name = "test"
+                version = "0.1.0"
                 readme = { }
             """,
             [


### PR DESCRIPTION
Slightly better error (was missing collection).

:robot: _AI text below_ :robot:

A non-string (unhashable) entry in `project.dynamic` — e.g. a nested list — made the PEP 808 dual-dynamic membership test (`field in data["project"]`) raise a raw `TypeError: unhashable type: 'list'` before the dedicated `project.dynamic` list validation could report a clean config error. This happened even with `all_errors=True`, where a collected diagnostic is expected.

Skipping non-string entries in that loop lets them be surfaced through the normal `error_collector` path instead. Added a regression test.

Closes #331