### PR TITLE
chore: bump to 0.12.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.1 (7-3-2026)
 
 Fixes:
 

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -77,7 +77,7 @@ if sys.version_info < (3, 12, 4):
     RE_EOL_BYTES = re.compile(rb"[\r\n]+")
 
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "ConfigurationError",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Patch release bumping the version to 0.12.1 and dating the changelog section for the one fix that landed since 0.12.0 (#332): collect a config error instead of raising a raw `TypeError` when `project.dynamic` contains a non-string (unhashable) entry with `all_errors=True`.