### PR TITLE
chore: drop Python 3.8 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
         os:
           - "ubuntu-latest"
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -33,13 +32,13 @@ jobs:
           - "3.15"
         include:
           - os: macos-15-intel
-            python: "3.8"
+            python: "3.9"
           - os: macos-14
             python: "3.12"
           - os: ubuntu-latest
             python: "pypy-3.11"
           - os: windows-latest
-            python: "3.8"
+            python: "3.9"
           - os: windows-latest
             python: "3.11"
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyproject-metadata"
 dynamic = ["version"]
 description = "PEP 621 metadata parsing"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject_metadata/_dispatch.py
+++ b/pyproject_metadata/_dispatch.py
@@ -85,8 +85,6 @@ def get_name(type_hint: type[object]) -> str:
     Get the name of a type hint as a readable modern Python type.
     """
     if origin := typing.get_origin(type_hint):
-        if args := typing.get_args(type_hint):
-            arg_names = ", ".join(get_name(a) for a in args)
-            return f"{origin.__name__}[{arg_names}]"
-        return origin.__name__  # type: ignore[no-any-return]
+        arg_names = ", ".join(get_name(a) for a in typing.get_args(type_hint))
+        return f"{origin.__name__}[{arg_names}]"
     return type_hint.__name__

--- a/pyproject_metadata/project_table.py
+++ b/pyproject_metadata/project_table.py
@@ -16,8 +16,6 @@ import sys
 import typing
 from typing import (
     Any,
-    Dict,
-    List,
     Literal,
     TypedDict,
     Union,
@@ -116,22 +114,22 @@ ProjectTable = TypedDict(
         "version": str,
         "description": str,
         "license": Union[LicenseTable, str],
-        "license-files": List[str],
+        "license-files": list[str],
         "readme": Union[str, ReadmeTable],
         "requires-python": str,
-        "dependencies": List[str],
-        "optional-dependencies": Dict[str, List[str]],
-        "entry-points": Dict[str, Dict[str, str]],
-        "authors": List[ContactTable],
-        "maintainers": List[ContactTable],
-        "urls": Dict[str, str],
-        "classifiers": List[str],
-        "keywords": List[str],
-        "scripts": Dict[str, str],
-        "gui-scripts": Dict[str, str],
-        "import-names": List[str],
-        "import-namespaces": List[str],
-        "dynamic": List[Dynamic],
+        "dependencies": list[str],
+        "optional-dependencies": dict[str, list[str]],
+        "entry-points": dict[str, dict[str, str]],
+        "authors": list[ContactTable],
+        "maintainers": list[ContactTable],
+        "urls": dict[str, str],
+        "classifiers": list[str],
+        "keywords": list[str],
+        "scripts": dict[str, str],
+        "gui-scripts": dict[str, str],
+        "import-names": list[str],
+        "import-namespaces": list[str],
+        "dynamic": list[Dynamic],
     },
     total=False,
 )
@@ -140,8 +138,8 @@ BuildSystemTable = TypedDict(
     "BuildSystemTable",
     {
         "build-backend": str,
-        "requires": List[str],
-        "backend-path": List[str],
+        "requires": list[str],
+        "backend-path": list[str],
     },
     total=False,
 )
@@ -159,8 +157,8 @@ PyProjectTable = TypedDict(
     {
         "build-system": BuildSystemTable,
         "project": ProjectTable,
-        "tool": Dict[str, Any],
-        "dependency-groups": Dict[str, List[Union[str, IncludeGroupTable]]],
+        "tool": dict[str, Any],
+        "dependency-groups": dict[str, list[Union[str, IncludeGroupTable]]],
     },
     total=False,
 )
@@ -293,7 +291,7 @@ def _(prefix: str, data: object, error_collector: SimpleErrorCollector) -> None:
         error_collector.error(ConfigurationError(msg, key=prefix))
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _get_type_hints(cls: type[object]) -> dict[str, Any]:
     """Cache ``typing.get_type_hints`` results per class."""
     return typing.get_type_hints(cls)

--- a/tests/packages/full-metadata/pyproject.toml
+++ b/tests/packages/full-metadata/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     'Programming Language :: Python',
 ]
 
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'dependency1',
     'dependency2>1.0.0',

--- a/tests/packages/full-metadata2/pyproject.toml
+++ b/tests/packages/full-metadata2/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     'Programming Language :: Python',
 ]
 
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'dependency1',
     'dependency2>1.0.0',

--- a/tests/packages/metadata-2.5/pyproject.toml
+++ b/tests/packages/metadata-2.5/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     'Programming Language :: Python',
 ]
 
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'dependency1',
     'dependency2>1.0.0',

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,5 +1,4 @@
 import sys
-import typing
 
 import pytest
 
@@ -29,8 +28,8 @@ def test_project_table_all() -> None:
 def test_get_name() -> None:
     get_name = pyproject_metadata._dispatch.get_name
     assert get_name(int) == "int"
-    assert get_name(typing.List[int]) == "list[int]"
-    assert get_name(typing.List) == "list"
+    assert get_name(list[int]) == "list[int]"
+    assert get_name(list) == "list"
 
 
 def test_ensure_list() -> None:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -1231,7 +1231,7 @@ def test_value(after_rfc: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     assert metadata.name == "full_metadata"
     assert metadata.canonical_name == "full-metadata"
     assert metadata.version == packaging.version.Version("3.2.1")
-    assert metadata.requires_python == packaging.specifiers.Specifier(">=3.8")
+    assert metadata.requires_python == packaging.specifiers.Specifier(">=3.9")
     assert isinstance(metadata.license, pyproject_metadata.License)
     assert metadata.license.file is None
     assert metadata.license.text == "some license text"
@@ -1334,12 +1334,15 @@ def test_readme_content_type(
 
 def test_readme_content_type_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(DIR / "packages/unknown-readme-type")
-    with pytest.raises(
-        pyproject_metadata.ConfigurationError,
-        match=re.escape(
-            "Could not infer content type for readme file 'README.just-made-this-up-now'"
+    with (
+        pytest.raises(
+            pyproject_metadata.ConfigurationError,
+            match=re.escape(
+                "Could not infer content type for readme file 'README.just-made-this-up-now'"
+            ),
         ),
-    ), open("pyproject.toml", "rb") as f:
+        open("pyproject.toml", "rb") as f,
+    ):
         pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
 
 
@@ -1382,7 +1385,7 @@ def test_as_json(monkeypatch: pytest.MonkeyPatch) -> None:
             'test_dependency[test_extra]; extra == "test"',
             'test_dependency[test_extra2]>3.0; os_name == "nt" and extra == "test"',
         ],
-        "requires_python": ">=3.8",
+        "requires_python": ">=3.9",
         "summary": "A package with all the metadata :)",
         "version": "3.2.1",
     }
@@ -1425,7 +1428,7 @@ def test_as_rfc822(monkeypatch: pytest.MonkeyPatch) -> None:
         ("Project-URL", "documentation, readthedocs.org"),
         ("Project-URL", "repository, github.com/some/repo"),
         ("Project-URL", "changelog, github.com/some/repo/blob/master/CHANGELOG.rst"),
-        ("Requires-Python", ">=3.8"),
+        ("Requires-Python", ">=3.9"),
         ("Requires-Dist", "dependency1"),
         ("Requires-Dist", "dependency2>1.0.0"),
         ("Requires-Dist", "dependency3[extra]"),


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Drops Python 3.8; the minimum is now 3.9.

- `requires-python = ">=3.9"`, 3.8 classifier removed
- CI: 3.8 removed from the matrix; oldest-version jobs (macOS Intel, Windows, mypy check) moved to 3.9
- Ruff auto-upgrades now allowed by the new floor: builtin generics (PEP 585) in the runtime-evaluated TypedDicts, `functools.cache`
- Test fixture packages bumped to `>=3.9`; `test_get_name` uses `list[int]` directly since the `typing.List` alias path is no longer used

No changelog entry, matching the fill-at-release pattern.